### PR TITLE
Default/Standard implementations of some PositionalGame functions

### DIFF
--- a/executable/Main.hs
+++ b/executable/Main.hs
@@ -73,6 +73,7 @@ import ColoredGraph (
   , mapEdges
   , rectOctGraph
   , coloredGraphSetPosition
+  , coloredGraphGetPosition
   , inARow)
 -------------------------------------------------------------------------------
 -- * TicTacToe
@@ -334,7 +335,7 @@ gridShowLine (Hex n b) y  = [rowOffset ++ tileTop ++ [x | y/=0, x <- " /"]
   tileTop = concat $ replicate hexSize " / \\"
 
 instance PositionalGame Hex (Int, Int) where
-  getPosition (Hex n b) c = fst <$> lookup c b
+  getPosition (Hex n b) = coloredGraphGetPosition b
   positions (Hex n b) = values b
   setPosition (Hex n b) = coloredGraphSetPosition (Hex n) b
   makeMove = takeEmptyMakeMove
@@ -362,7 +363,7 @@ instance Show Havannah where
   show (Havannah b) = show b
 
 instance PositionalGame Havannah (Int, Int) where
-  getPosition (Havannah b) c = fst <$> lookup c b
+  getPosition (Havannah b) = coloredGraphGetPosition b
   positions (Havannah b) = values b
   setPosition (Havannah b) = coloredGraphSetPosition Havannah b
   makeMove = takeEmptyMakeMove
@@ -399,7 +400,7 @@ instance Show Yavalath where
   show (Yavalath b) = show b
 
 instance PositionalGame Yavalath (Int, Int) where
-  getPosition (Yavalath b) c = fst <$> lookup c b
+  getPosition (Yavalath b) = coloredGraphGetPosition b
   positions (Yavalath b) = values b
   setPosition (Yavalath b) = coloredGraphSetPosition Yavalath b
   makeMove = takeEmptyMakeMove
@@ -441,7 +442,7 @@ instance Show MNKGame where
   show (MNKGame k b) = show b
 
 instance PositionalGame MNKGame (Int, Int) where
-  getPosition (MNKGame k b) c = fst <$> lookup c b
+  getPosition (MNKGame k b) = coloredGraphGetPosition b
   positions (MNKGame k b) = values b
   setPosition (MNKGame k b) = coloredGraphSetPosition (MNKGame k) b
   makeMove = takeEmptyMakeMove

--- a/executable/Main.hs
+++ b/executable/Main.hs
@@ -63,7 +63,7 @@ import Math.Geometry.Grid as Grid ()
 import Math.Geometry.Grid.Hexagonal ()
 import ColoredGraph (
     ColoredGraph
-  , ColoredGraphPositionalGame(..)
+  , ColoredGraphVerticesPositionalGame(..)
   , paraHexGraph
   , values
   , anyConnections
@@ -74,8 +74,6 @@ import ColoredGraph (
   , hexHexGraph
   , mapEdges
   , rectOctGraph
-  , coloredGraphSetPosition
-  , coloredGraphGetPosition
   , inARow)
 -------------------------------------------------------------------------------
 -- * TicTacToe
@@ -331,7 +329,7 @@ gridShowLine (Hex n b) y  = [rowOffset ++ tileTop ++ [x | y/=0, x <- " /"]
   rowOffset = replicate (2*(hexSize-y-1)) ' '
   tileTop = concat $ replicate hexSize " / \\"
 
-instance ColoredGraphPositionalGame (Int, Int) Player (Int, Int) Hex where
+instance ColoredGraphVerticesPositionalGame (Int, Int) Player (Int, Int) Hex where
   toColoredGraph (Hex n b) = b
   fromColoredGraph (Hex n _) = Hex n
 
@@ -355,7 +353,7 @@ instance PositionalGame Hex (Int, Int) where
 -------------------------------------------------------------------------------
 
 newtype Havannah = Havannah (ColoredGraph (Int, Int) (Maybe Player) ())
-  deriving (ColoredGraphPositionalGame (Int, Int) Player ())
+  deriving (ColoredGraphVerticesPositionalGame (Int, Int) Player ())
 
 instance Show Havannah where
   show (Havannah b) = show b
@@ -388,7 +386,7 @@ emptyHavannah = Havannah . mapEdges (const ()) . hexHexGraph
 -------------------------------------------------------------------------------
 
 newtype Yavalath = Yavalath (ColoredGraph (Int, Int) (Maybe Player) String)
-  deriving (ColoredGraphPositionalGame (Int, Int) Player String)
+  deriving (ColoredGraphVerticesPositionalGame (Int, Int) Player String)
 
 instance Show Yavalath where
   show (Yavalath b) = show b
@@ -430,7 +428,7 @@ data MNKGame = MNKGame Int (ColoredGraph (Int, Int) (Maybe Player) String)
 instance Show MNKGame where
   show (MNKGame k b) = show b
 
-instance ColoredGraphPositionalGame (Int, Int) Player String MNKGame where
+instance ColoredGraphVerticesPositionalGame (Int, Int) Player String MNKGame where
   toColoredGraph (MNKGame n b) = b
   fromColoredGraph (MNKGame n _) = MNKGame n
 

--- a/executable/Main.hs
+++ b/executable/Main.hs
@@ -72,6 +72,7 @@ import ColoredGraph (
   , hexHexGraph
   , mapEdges
   , rectOctGraph
+  , coloredGraphSetPosition
   , inARow)
 -------------------------------------------------------------------------------
 -- * TicTacToe
@@ -335,9 +336,7 @@ gridShowLine (Hex n b) y  = [rowOffset ++ tileTop ++ [x | y/=0, x <- " /"]
 instance PositionalGame Hex (Int, Int) where
   getPosition (Hex n b) c = fst <$> lookup c b
   positions (Hex n b) = values b
-  setPosition (Hex n b) c p = if member c b
-    then Just $ Hex n $ adjust (\(_, xs) -> (Just p, xs)) c b
-    else Nothing
+  setPosition (Hex n b) = coloredGraphSetPosition (Hex n) b
   makeMove = takeEmptyMakeMove
   gameOver (Hex n b) = criterion b
     where
@@ -365,9 +364,7 @@ instance Show Havannah where
 instance PositionalGame Havannah (Int, Int) where
   getPosition (Havannah b) c = fst <$> lookup c b
   positions (Havannah b) = values b
-  setPosition (Havannah b) c p = if member c b
-    then Just $ Havannah $ adjust (\(_, xs) -> (Just p, xs)) c b
-    else Nothing
+  setPosition (Havannah b) = coloredGraphSetPosition Havannah b
   makeMove = takeEmptyMakeMove
 
   gameOver (Havannah b) = criterion b
@@ -404,9 +401,7 @@ instance Show Yavalath where
 instance PositionalGame Yavalath (Int, Int) where
   getPosition (Yavalath b) c = fst <$> lookup c b
   positions (Yavalath b) = values b
-  setPosition (Yavalath b) c p = if member c b
-    then Just $ Yavalath $ adjust (\(_, xs) -> (Just p, xs)) c b
-    else Nothing
+  setPosition (Yavalath b) = coloredGraphSetPosition Yavalath b
   makeMove = takeEmptyMakeMove
 
   gameOver (Yavalath b) = criterion b
@@ -448,9 +443,7 @@ instance Show MNKGame where
 instance PositionalGame MNKGame (Int, Int) where
   getPosition (MNKGame k b) c = fst <$> lookup c b
   positions (MNKGame k b) = values b
-  setPosition (MNKGame k b) c p = if member c b
-    then Just $ MNKGame k $ adjust (\(_, xs) -> (Just p, xs)) c b
-    else Nothing
+  setPosition (MNKGame k b) = coloredGraphSetPosition (MNKGame k) b
   makeMove = takeEmptyMakeMove
 
   gameOver (MNKGame k b) = criterion b

--- a/executable/Main.hs
+++ b/executable/Main.hs
@@ -128,8 +128,6 @@ instance PositionalGame TicTacToe (Integer, Integer) where
   positions (TicTacToe b) = elems b
   -- If the underlying Map has the given coordinate, update it with the given player
   setPosition (TicTacToe b) c p = if member c b then Just $ TicTacToe $ insert c (Just p) b else Nothing
-  -- Just uses the "standard" implementation
-  makeMove = takeEmptyMakeMove
   -- "Creates" a `gameOver` function by supplying all the winning "patterns"
   gameOver = patternMatchingGameOver [
       [(0, 0), (0, 1), (0, 2)]
@@ -168,7 +166,6 @@ instance PositionalGame ArithmeticProgressionGame Int where
   setPosition (ArithmeticProgressionGame k l) i p = if i <= length l
     then Just $ ArithmeticProgressionGame k (take (i - 1) l ++ Just p : drop i l)
     else Nothing
-  makeMove = takeEmptyMakeMove
   gameOver a@(ArithmeticProgressionGame k l) = let n = length l
     in patternMatchingGameOver (filter (all (<= n)) $ concat [[take k [i,i+j..] | j <- [1..n-i]] | i <- [1..n]]) a
 
@@ -212,7 +209,6 @@ instance PositionalGame ShannonSwitchingGame (Int, Int) where
   setPosition (ShannonSwitchingGame (n, l)) c p = case findIndex ((== c) . fst) l of
     Just i -> Just $ ShannonSwitchingGame (n, take i l ++ (c, Just p) : drop (i + 1) l)
     Nothing -> Nothing
-  makeMove = takeEmptyMakeMove
   gameOver (ShannonSwitchingGame (n, l))
     | path g 0 (n * n - 1) = Just (Just Player1)
     | path g (n - 1) (n * n - n) = Just (Just Player2)
@@ -280,7 +276,6 @@ instance PositionalGame Gale (Integer, Integer) where
   positions (Gale b) = elems b
   setPosition (Gale b) (x, y) p = if x `rem` 2 == y `rem` 2 && member c b then Just $ Gale $ insert c (Just p) b else Nothing
     where c = (x `div` 2, y)
-  makeMove = takeEmptyMakeMove
   gameOver (Gale b)
     | all isJust (elems b) = Just Nothing
     | path player1Graph (-1) (-2) = Just $ Just Player1

--- a/executable/Main.hs
+++ b/executable/Main.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Main where
 
@@ -330,7 +331,7 @@ gridShowLine (Hex n b) y  = [rowOffset ++ tileTop ++ [x | y/=0, x <- " /"]
   rowOffset = replicate (2*(hexSize-y-1)) ' '
   tileTop = concat $ replicate hexSize " / \\"
 
-instance ColoredGraphPositionalGame Hex (Int, Int) Player (Int, Int) where
+instance ColoredGraphPositionalGame (Int, Int) Player (Int, Int) Hex where
   toColoredGraph (Hex n b) = b
   fromColoredGraph (Hex n _) = Hex n
 
@@ -354,13 +355,10 @@ instance PositionalGame Hex (Int, Int) where
 -------------------------------------------------------------------------------
 
 newtype Havannah = Havannah (ColoredGraph (Int, Int) (Maybe Player) ())
+  deriving (ColoredGraphPositionalGame (Int, Int) Player ())
 
 instance Show Havannah where
   show (Havannah b) = show b
-
-instance ColoredGraphPositionalGame Havannah (Int, Int) Player () where
-  toColoredGraph (Havannah b) = b
-  fromColoredGraph _ = Havannah
 
 instance PositionalGame Havannah (Int, Int) where
   gameOver (Havannah b) = criterion b
@@ -390,13 +388,10 @@ emptyHavannah = Havannah . mapEdges (const ()) . hexHexGraph
 -------------------------------------------------------------------------------
 
 newtype Yavalath = Yavalath (ColoredGraph (Int, Int) (Maybe Player) String)
+  deriving (ColoredGraphPositionalGame (Int, Int) Player String)
 
 instance Show Yavalath where
   show (Yavalath b) = show b
-
-instance ColoredGraphPositionalGame Yavalath (Int, Int) Player String where
-  toColoredGraph (Yavalath b) = b
-  fromColoredGraph _ = Yavalath
 
 instance PositionalGame Yavalath (Int, Int) where
   gameOver (Yavalath b) = criterion b
@@ -435,7 +430,7 @@ data MNKGame = MNKGame Int (ColoredGraph (Int, Int) (Maybe Player) String)
 instance Show MNKGame where
   show (MNKGame k b) = show b
 
-instance ColoredGraphPositionalGame MNKGame (Int, Int) Player String where
+instance ColoredGraphPositionalGame (Int, Int) Player String MNKGame where
   toColoredGraph (MNKGame n b) = b
   fromColoredGraph (MNKGame n _) = MNKGame n
 

--- a/executable/Main.hs
+++ b/executable/Main.hs
@@ -62,6 +62,7 @@ import Math.Geometry.Grid as Grid ()
 import Math.Geometry.Grid.Hexagonal ()
 import ColoredGraph (
     ColoredGraph
+  , ColoredGraphPositionalGame(..)
   , paraHexGraph
   , values
   , anyConnections
@@ -329,11 +330,11 @@ gridShowLine (Hex n b) y  = [rowOffset ++ tileTop ++ [x | y/=0, x <- " /"]
   rowOffset = replicate (2*(hexSize-y-1)) ' '
   tileTop = concat $ replicate hexSize " / \\"
 
+instance ColoredGraphPositionalGame Hex (Int, Int) Player (Int, Int) where
+  toColoredGraph (Hex n b) = b
+  fromColoredGraph (Hex n _) = Hex n
+
 instance PositionalGame Hex (Int, Int) where
-  getPosition (Hex n b) = coloredGraphGetPosition b
-  positions (Hex n b) = values b
-  setPosition (Hex n b) = coloredGraphSetPosition (Hex n) b
-  makeMove = takeEmptyMakeMove
   gameOver (Hex n b) = criterion b
     where
       criterion =
@@ -357,12 +358,11 @@ newtype Havannah = Havannah (ColoredGraph (Int, Int) (Maybe Player) ())
 instance Show Havannah where
   show (Havannah b) = show b
 
-instance PositionalGame Havannah (Int, Int) where
-  getPosition (Havannah b) = coloredGraphGetPosition b
-  positions (Havannah b) = values b
-  setPosition (Havannah b) = coloredGraphSetPosition Havannah b
-  makeMove = takeEmptyMakeMove
+instance ColoredGraphPositionalGame Havannah (Int, Int) Player () where
+  toColoredGraph (Havannah b) = b
+  fromColoredGraph _ = Havannah
 
+instance PositionalGame Havannah (Int, Int) where
   gameOver (Havannah b) = criterion b
     where
       criterion =
@@ -394,12 +394,11 @@ newtype Yavalath = Yavalath (ColoredGraph (Int, Int) (Maybe Player) String)
 instance Show Yavalath where
   show (Yavalath b) = show b
 
-instance PositionalGame Yavalath (Int, Int) where
-  getPosition (Yavalath b) = coloredGraphGetPosition b
-  positions (Yavalath b) = values b
-  setPosition (Yavalath b) = coloredGraphSetPosition Yavalath b
-  makeMove = takeEmptyMakeMove
+instance ColoredGraphPositionalGame Yavalath (Int, Int) Player String where
+  toColoredGraph (Yavalath b) = b
+  fromColoredGraph _ = Yavalath
 
+instance PositionalGame Yavalath (Int, Int) where
   gameOver (Yavalath b) = criterion b
     where
       criterion =
@@ -436,12 +435,11 @@ data MNKGame = MNKGame Int (ColoredGraph (Int, Int) (Maybe Player) String)
 instance Show MNKGame where
   show (MNKGame k b) = show b
 
-instance PositionalGame MNKGame (Int, Int) where
-  getPosition (MNKGame k b) = coloredGraphGetPosition b
-  positions (MNKGame k b) = values b
-  setPosition (MNKGame k b) = coloredGraphSetPosition (MNKGame k) b
-  makeMove = takeEmptyMakeMove
+instance ColoredGraphPositionalGame MNKGame (Int, Int) Player String where
+  toColoredGraph (MNKGame n b) = b
+  fromColoredGraph (MNKGame n _) = MNKGame n
 
+instance PositionalGame MNKGame (Int, Int) where
   gameOver (MNKGame k b) = criterion b
     where
       criterion =

--- a/src/ColoredGraph.hs
+++ b/src/ColoredGraph.hs
@@ -4,7 +4,7 @@
 
 module ColoredGraph (
     ColoredGraph
-  , ColoredGraphPositionalGame(..)
+  , ColoredGraphVerticesPositionalGame(..)
   , hexHexGraph
   , paraHexGraph
   , rectOctGraph
@@ -17,8 +17,8 @@ module ColoredGraph (
   , anyConnections
   , inARow
   , values
-  , coloredGraphSetPosition
-  , coloredGraphGetPosition
+  , coloredGraphSetVertexPosition
+  , coloredGraphGetVertexPosition
 ) where
 
 import Data.Map (Map)
@@ -231,27 +231,28 @@ inARow :: (Ord i, Eq b) => (Int -> Bool) -> b -> ColoredGraph i a b -> Bool
 inARow pred dir = any (pred . length) . components . filterEdges (==dir)
 
 -- | A standard implementation of 'MyLib.getPosition' for games
---   with an underlying 'ColoredGraph'.
-coloredGraphGetPosition :: Ord i => ColoredGraph i (Maybe a) b -> i -> Maybe (Maybe a)
-coloredGraphGetPosition c i = fst <$> Map.lookup i c
+--   with an underlying 'ColoredGraph' played on the vertices.
+coloredGraphGetVertexPosition :: Ord i => ColoredGraph i (Maybe a) b -> i -> Maybe (Maybe a)
+coloredGraphGetVertexPosition c i = fst <$> Map.lookup i c
 
 -- | A standard implementation of 'MyLib.setPosition' for games
---   with an underlying 'ColoredGraph'.
-coloredGraphSetPosition :: Ord i => (ColoredGraph i (Maybe a) b -> c) -> ColoredGraph i (Maybe a) b -> i -> a -> Maybe c
-coloredGraphSetPosition constructor c i p = if Map.member i c
+--   with an underlying 'ColoredGraph' played on the vertices.
+coloredGraphSetVertexPosition :: Ord i => (ColoredGraph i (Maybe a) b -> c) -> ColoredGraph i (Maybe a) b -> i -> a -> Maybe c
+coloredGraphSetVertexPosition constructor c i p = if Map.member i c
     then Just $ constructor $ Map.adjust (\(_, xs) -> (Just p, xs)) i c
     else Nothing
 
 -- | A class for games based on 'ColoredGraph's that allows them to use default
---   implementations of functions in 'MyLib.PositionalGame'.
+--   implementations of functions in 'MyLib.PositionalGame'. Game of the class
+--   are played on the vertices of of the graph.
 --
 --   New-types of 'ColoredGraph' can derive this using the
 --   'GeneralizedNewtypeDeriving' language extension.
-class ColoredGraphPositionalGame i a b g | g -> i, g -> a, g -> b where
+class ColoredGraphVerticesPositionalGame i a b g | g -> i, g -> a, g -> b where
   toColoredGraph :: g -> ColoredGraph i (Maybe a) b
   fromColoredGraph :: g -> ColoredGraph i (Maybe a) b -> g
 
-instance ColoredGraphPositionalGame i a b (ColoredGraph i (Maybe a) b) where
+instance ColoredGraphVerticesPositionalGame i a b (ColoredGraph i (Maybe a) b) where
   toColoredGraph c = c
   fromColoredGraph _ = id
 

--- a/src/ColoredGraph.hs
+++ b/src/ColoredGraph.hs
@@ -15,6 +15,7 @@ module ColoredGraph (
   , inARow
   , values
   , coloredGraphSetPosition
+  , coloredGraphGetPosition
 ) where
 
 import Data.Map (Map)
@@ -225,6 +226,11 @@ anyConnections pred groups g = any (\z -> pred $ length $ filter (not . Prelude.
 --   accepted by `pred`.
 inARow :: (Ord i, Eq b) => (Int -> Bool) -> b -> ColoredGraph i a b -> Bool
 inARow pred dir = any (pred . length) . components . filterEdges (==dir)
+
+-- | A standard implementation of 'MyLib.getPosition' for games
+--   with an underlying 'ColoredGraph'.
+coloredGraphGetPosition :: Ord i => ColoredGraph i (Maybe a) b -> i -> Maybe (Maybe a)
+coloredGraphGetPosition c i = fst <$> Map.lookup i c
 
 -- | A standard implementation of 'MyLib.setPosition' for games
 --   with an underlying 'ColoredGraph'.

--- a/src/ColoredGraph.hs
+++ b/src/ColoredGraph.hs
@@ -242,6 +242,11 @@ coloredGraphSetPosition constructor c i p = if Map.member i c
     then Just $ constructor $ Map.adjust (\(_, xs) -> (Just p, xs)) i c
     else Nothing
 
+-- | A class for games based on 'ColoredGraph's that allows them to use default
+--   implementations of functions in 'MyLib.PositionalGame'.
+--
+--   New-types of 'ColoredGraph' can derive this using the
+--   'GeneralizedNewtypeDeriving' language extension.
 class ColoredGraphPositionalGame i a b g | g -> i, g -> a, g -> b where
   toColoredGraph :: g -> ColoredGraph i (Maybe a) b
   fromColoredGraph :: g -> ColoredGraph i (Maybe a) b -> g

--- a/src/ColoredGraph.hs
+++ b/src/ColoredGraph.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE FunctionalDependencies #-}
 
 module ColoredGraph (
     ColoredGraph
+  , ColoredGraphPositionalGame(..)
   , hexHexGraph
   , paraHexGraph
   , rectOctGraph
@@ -239,6 +241,9 @@ coloredGraphSetPosition constructor c i p = if Map.member i c
     then Just $ constructor $ Map.adjust (\(_, xs) -> (Just p, xs)) i c
     else Nothing
 
+class ColoredGraphPositionalGame g i a b | g -> i, g -> a, g -> b where
+  toColoredGraph :: g -> ColoredGraph i (Maybe a) b
+  fromColoredGraph :: g -> ColoredGraph i (Maybe a) b -> g
 
 
 

--- a/src/ColoredGraph.hs
+++ b/src/ColoredGraph.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE FlexibleInstances #-}
 
 module ColoredGraph (
     ColoredGraph
@@ -241,10 +242,13 @@ coloredGraphSetPosition constructor c i p = if Map.member i c
     then Just $ constructor $ Map.adjust (\(_, xs) -> (Just p, xs)) i c
     else Nothing
 
-class ColoredGraphPositionalGame g i a b | g -> i, g -> a, g -> b where
+class ColoredGraphPositionalGame i a b g | g -> i, g -> a, g -> b where
   toColoredGraph :: g -> ColoredGraph i (Maybe a) b
   fromColoredGraph :: g -> ColoredGraph i (Maybe a) b -> g
 
+instance ColoredGraphPositionalGame i a b (ColoredGraph i (Maybe a) b) where
+  toColoredGraph c = c
+  fromColoredGraph _ = id
 
 
 

--- a/src/ColoredGraph.hs
+++ b/src/ColoredGraph.hs
@@ -14,6 +14,7 @@ module ColoredGraph (
   , anyConnections
   , inARow
   , values
+  , coloredGraphSetPosition
 ) where
 
 import Data.Map (Map)
@@ -225,6 +226,12 @@ anyConnections pred groups g = any (\z -> pred $ length $ filter (not . Prelude.
 inARow :: (Ord i, Eq b) => (Int -> Bool) -> b -> ColoredGraph i a b -> Bool
 inARow pred dir = any (pred . length) . components . filterEdges (==dir)
 
+-- | A standard implementation of 'MyLib.setPosition' for games
+--   with an underlying 'ColoredGraph'.
+coloredGraphSetPosition :: Ord i => (ColoredGraph i (Maybe a) b -> c) -> ColoredGraph i (Maybe a) b -> i -> a -> Maybe c
+coloredGraphSetPosition constructor c i p = if Map.member i c
+    then Just $ constructor $ Map.adjust (\(_, xs) -> (Just p, xs)) i c
+    else Nothing
 
 
 

--- a/src/MyLib.hs
+++ b/src/MyLib.hs
@@ -32,10 +32,10 @@ import Text.Read (readMaybe)
 import Control.Monad (join, foldM)
 import Control.Applicative ((<|>))
 import ColoredGraph (
-    ColoredGraphPositionalGame(..)
+    ColoredGraphVerticesPositionalGame(..)
   , values
-  , coloredGraphGetPosition
-  , coloredGraphSetPosition
+  , coloredGraphGetVertexPosition
+  , coloredGraphSetVertexPosition
   )
 #ifdef WASM
 import Data.Aeson (ToJSON(toJSON), Value(Number))
@@ -79,7 +79,7 @@ class PositionalGame a c | a -> c where
   gameOver :: a -> Maybe (Maybe Player)
   -- | Returns a list of all positions. Not in any particular order.
   positions :: a -> [Maybe Player]
-  default positions :: (ColoredGraphPositionalGame c Player e a) => a -> [Maybe Player]
+  default positions :: (ColoredGraphVerticesPositionalGame c Player e a) => a -> [Maybe Player]
   positions = values . toColoredGraph
   -- | Returns which player (or nothing) has taken the position at the given
   --   coordinate, or 'Nothing' if the given coordinate is invalid.
@@ -88,13 +88,13 @@ class PositionalGame a c | a -> c where
   -- > Just (Just p) -- Player p owns this position
   -- > Just Nothing  -- This position is empty
   getPosition :: a -> c -> Maybe (Maybe Player)
-  default getPosition :: (ColoredGraphPositionalGame c Player e a, Ord c) => a -> c -> Maybe (Maybe Player)
-  getPosition = coloredGraphGetPosition . toColoredGraph
+  default getPosition :: (ColoredGraphVerticesPositionalGame c Player e a, Ord c) => a -> c -> Maybe (Maybe Player)
+  getPosition = coloredGraphGetVertexPosition . toColoredGraph
   -- | Takes the position at the given coordinate for the given player and
   --   returns the new state, or 'Nothing' if the given coordinate is invalid.
   setPosition :: a -> c -> Player -> Maybe a
-  default setPosition :: (ColoredGraphPositionalGame c Player e a, Ord c) => a -> c -> Player -> Maybe a
-  setPosition g = coloredGraphSetPosition (fromColoredGraph g) $ toColoredGraph g
+  default setPosition :: (ColoredGraphVerticesPositionalGame c Player e a, Ord c) => a -> c -> Player -> Maybe a
+  setPosition g = coloredGraphSetVertexPosition (fromColoredGraph g) $ toColoredGraph g
 
 -- | A standard implementation of 'makeMove' for a 'PositionalGame'.
 --   Only allows move that "take" empty existing positions.

--- a/src/MyLib.hs
+++ b/src/MyLib.hs
@@ -58,7 +58,10 @@ instance ToJSON Player where
 class PositionalGame a c | a -> c where
   -- | Takes the "current" state, a player, and a coordinate. Returns the new
   --   state if the move is valid.
+  --
+  --   The default implementation is 'takeEmptyMakeMove'.
   makeMove :: a -> Player -> c -> Maybe a
+  makeMove = takeEmptyMakeMove
   -- | Takes the "current" state and checks if the game is over, in which case
   --   the victorious player is returned or nothing in case of a draw.
   --

--- a/src/MyLib.hs
+++ b/src/MyLib.hs
@@ -79,7 +79,7 @@ class PositionalGame a c | a -> c where
   gameOver :: a -> Maybe (Maybe Player)
   -- | Returns a list of all positions. Not in any particular order.
   positions :: a -> [Maybe Player]
-  default positions :: (ColoredGraphPositionalGame a c Player e) => a -> [Maybe Player]
+  default positions :: (ColoredGraphPositionalGame c Player e a) => a -> [Maybe Player]
   positions = values . toColoredGraph
   -- | Returns which player (or nothing) has taken the position at the given
   --   coordinate, or 'Nothing' if the given coordinate is invalid.
@@ -88,12 +88,12 @@ class PositionalGame a c | a -> c where
   -- > Just (Just p) -- Player p owns this position
   -- > Just Nothing  -- This position is empty
   getPosition :: a -> c -> Maybe (Maybe Player)
-  default getPosition :: (ColoredGraphPositionalGame a c Player e, Ord c) => a -> c -> Maybe (Maybe Player)
+  default getPosition :: (ColoredGraphPositionalGame c Player e a, Ord c) => a -> c -> Maybe (Maybe Player)
   getPosition = coloredGraphGetPosition . toColoredGraph
   -- | Takes the position at the given coordinate for the given player and
   --   returns the new state, or 'Nothing' if the given coordinate is invalid.
   setPosition :: a -> c -> Player -> Maybe a
-  default setPosition :: (ColoredGraphPositionalGame a c Player e, Ord c) => a -> c -> Player -> Maybe a
+  default setPosition :: (ColoredGraphPositionalGame c Player e a, Ord c) => a -> c -> Player -> Maybe a
   setPosition g = coloredGraphSetPosition (fromColoredGraph g) $ toColoredGraph g
 
 -- | A standard implementation of 'makeMove' for a 'PositionalGame'.


### PR DESCRIPTION
Additional help for game that are based on a `ColoredGraph`.

All functions but `gameOver` can be derived for newtypes of `ColoredGraph`s. More complex types can implement `ColoredGraphPositionalGame`s two functions, and receives four functions in `PositionalGame` for free.