### PR TITLE
Standard ColoredGraph on vertices with narrowed ColoredGraph

### DIFF
--- a/executable/Main.hs
+++ b/executable/Main.hs
@@ -242,10 +242,14 @@ data ShannonSwitchingGameCG = ShannonSwitchingGameCG {
   }
   deriving (Show)
 
+instance ColoredGraphTransformer Int () (Maybe Player) ShannonSwitchingGameCG where
+  toColoredGraph = graph
+  fromColoredGraph ssg graph = ssg{ graph }
+
 instance PositionalGame ShannonSwitchingGameCG (Int, Int) where
-  positions ShannonSwitchingGameCG{ graph } = coloredGraphEdgePositions graph
-  getPosition ShannonSwitchingGameCG{ graph } = coloredGraphGetEdgePosition graph
-  setPosition ssg@ShannonSwitchingGameCG{ graph } c p = (\g -> ssg{ graph = g }) <$> coloredGraphSetBidirectedEdgePosition graph c (Just p)
+  positions = coloredGraphEdgePositions
+  getPosition = coloredGraphGetEdgePosition
+  setPosition ssg c p = coloredGraphSetBidirectedEdgePosition ssg c (Just p)
   gameOver ShannonSwitchingGameCG{ start, goal, graph } =
       ifNotThen (player1WinsIf winPath) (player1LosesIf losePath) graph
     where
@@ -404,8 +408,8 @@ instance ColoredGraphTransformer (Int, Int) (Maybe Player) (Int, Int) Hex where
 
 instance PositionalGame Hex (Int, Int) where
   positions (Hex _ b) = values b
-  getPosition (Hex _ b) = coloredGraphGetVertexPosition b
-  setPosition (Hex n b) c p = Hex n <$> coloredGraphSetVertexPosition b c (Just p)
+  getPosition = coloredGraphGetVertexPosition
+  setPosition g c p = coloredGraphSetVertexPosition g c (Just p)
   gameOver (Hex n b) = criterion b
     where
       criterion =
@@ -432,8 +436,8 @@ instance Show Havannah where
 
 instance PositionalGame Havannah (Int, Int) where
   positions (Havannah b) = values b
-  getPosition (Havannah b) = coloredGraphGetVertexPosition b
-  setPosition (Havannah b) c p = Havannah <$> coloredGraphSetVertexPosition b c (Just p)
+  getPosition = coloredGraphGetVertexPosition
+  setPosition g c p = coloredGraphSetVertexPosition g c (Just p)
   gameOver (Havannah b) = criterion b
     where
       criterion =
@@ -468,8 +472,8 @@ instance Show Yavalath where
 
 instance PositionalGame Yavalath (Int, Int) where
   positions (Yavalath b) = values b
-  getPosition (Yavalath b) = coloredGraphGetVertexPosition b
-  setPosition (Yavalath b) c p = Yavalath <$> coloredGraphSetVertexPosition b c (Just p)
+  getPosition = coloredGraphGetVertexPosition
+  setPosition g c p = coloredGraphSetVertexPosition g c (Just p)
   gameOver (Yavalath b) = criterion b
     where
       criterion =
@@ -512,8 +516,8 @@ instance ColoredGraphTransformer (Int, Int) (Maybe Player) String MNKGame where
 
 instance PositionalGame MNKGame (Int, Int) where
   positions (MNKGame _ b) = values b
-  getPosition (MNKGame _ b) = coloredGraphGetVertexPosition b
-  setPosition (MNKGame n b) c p = MNKGame n <$> coloredGraphSetVertexPosition b c (Just p)
+  getPosition = coloredGraphGetVertexPosition
+  setPosition g c p = coloredGraphSetVertexPosition g c (Just p)
   gameOver (MNKGame k b) = criterion b
     where
       criterion =

--- a/executable/Main.hs
+++ b/executable/Main.hs
@@ -250,7 +250,7 @@ instance ColoredGraphTransformer Int () (Maybe Player) ShannonSwitchingGameCG wh
 instance PositionalGame ShannonSwitchingGameCG (Int, Int) where
   positions = coloredGraphEdgePositions
   getPosition = coloredGraphGetEdgePosition
-  setPosition ssg c p = coloredGraphSetBidirectedEdgePosition ssg c (Just p)
+  setPosition = coloredGraphSetBidirectedEdgePosition
   gameOver ShannonSwitchingGameCG{ start, goal, graph } =
       ifNotThen (player1WinsIf winPath) (player1LosesIf losePath) graph
     where
@@ -410,7 +410,7 @@ instance ColoredGraphTransformer (Int, Int) (Maybe Player) (Int, Int) Hex where
 instance PositionalGame Hex (Int, Int) where
   positions = coloredGraphVertexPositions
   getPosition = coloredGraphGetVertexPosition
-  setPosition g c p = coloredGraphSetVertexPosition g c (Just p)
+  setPosition = coloredGraphSetVertexPosition
   gameOver (Hex n b) = criterion b
     where
       criterion =
@@ -438,7 +438,7 @@ instance Show Havannah where
 instance PositionalGame Havannah (Int, Int) where
   positions = coloredGraphVertexPositions
   getPosition = coloredGraphGetVertexPosition
-  setPosition g c p = coloredGraphSetVertexPosition g c (Just p)
+  setPosition = coloredGraphSetVertexPosition
   gameOver (Havannah b) = criterion b
     where
       criterion =
@@ -474,7 +474,7 @@ instance Show Yavalath where
 instance PositionalGame Yavalath (Int, Int) where
   positions = coloredGraphVertexPositions
   getPosition = coloredGraphGetVertexPosition
-  setPosition g c p = coloredGraphSetVertexPosition g c (Just p)
+  setPosition = coloredGraphSetVertexPosition
   gameOver (Yavalath b) = criterion b
     where
       criterion =
@@ -518,7 +518,7 @@ instance ColoredGraphTransformer (Int, Int) (Maybe Player) String MNKGame where
 instance PositionalGame MNKGame (Int, Int) where
   positions = coloredGraphVertexPositions
   getPosition = coloredGraphGetVertexPosition
-  setPosition g c p = coloredGraphSetVertexPosition g c (Just p)
+  setPosition = coloredGraphSetVertexPosition
   gameOver (MNKGame k b) = criterion b
     where
       criterion =

--- a/executable/Main.hs
+++ b/executable/Main.hs
@@ -399,11 +399,11 @@ gridShowLine (Hex n b) y  = [rowOffset ++ tileTop ++ [x | y/=0, x <- " /"]
   rowOffset = replicate (2*(hexSize-y-1)) ' '
   tileTop = concat $ replicate hexSize " / \\"
 
-instance ColoredGraphTransformer (Int, Int) Player (Int, Int) Hex where
+instance ColoredGraphTransformer (Int, Int) (Maybe Player) (Int, Int) Hex where
   toColoredGraph (Hex n b) = b
   fromColoredGraph (Hex n _) = Hex n
 
-instance ColoredGraphVerticesPositionalGame (Int, Int) Player (Int, Int) Hex
+instance ColoredGraphVerticesPositionalGame (Int, Int) (Maybe Player) (Int, Int) Hex
 
 instance PositionalGame Hex (Int, Int) where
   gameOver (Hex n b) = criterion b
@@ -425,7 +425,7 @@ instance PositionalGame Hex (Int, Int) where
 -------------------------------------------------------------------------------
 
 newtype Havannah = Havannah (ColoredGraph (Int, Int) (Maybe Player) ())
-  deriving (ColoredGraphTransformer (Int, Int) Player (), ColoredGraphVerticesPositionalGame (Int, Int) Player ())
+  deriving (ColoredGraphTransformer (Int, Int) (Maybe Player) (), ColoredGraphVerticesPositionalGame (Int, Int) (Maybe Player) ())
 
 instance Show Havannah where
   show (Havannah b) = show b
@@ -458,7 +458,7 @@ emptyHavannah = Havannah . mapEdges (const ()) . hexHexGraph
 -------------------------------------------------------------------------------
 
 newtype Yavalath = Yavalath (ColoredGraph (Int, Int) (Maybe Player) String)
-  deriving (ColoredGraphTransformer (Int, Int) Player String, ColoredGraphVerticesPositionalGame (Int, Int) Player String)
+  deriving (ColoredGraphTransformer (Int, Int) (Maybe Player) String, ColoredGraphVerticesPositionalGame (Int, Int) (Maybe Player) String)
 
 instance Show Yavalath where
   show (Yavalath b) = show b
@@ -500,11 +500,11 @@ data MNKGame = MNKGame Int (ColoredGraph (Int, Int) (Maybe Player) String)
 instance Show MNKGame where
   show (MNKGame k b) = show b
 
-instance ColoredGraphTransformer (Int, Int) Player String MNKGame where
+instance ColoredGraphTransformer (Int, Int) (Maybe Player) String MNKGame where
   toColoredGraph (MNKGame n b) = b
   fromColoredGraph (MNKGame n _) = MNKGame n
 
-instance ColoredGraphVerticesPositionalGame (Int, Int) Player String MNKGame
+instance ColoredGraphVerticesPositionalGame (Int, Int) (Maybe Player) String MNKGame
 
 instance PositionalGame MNKGame (Int, Int) where
   gameOver (MNKGame k b) = criterion b

--- a/executable/Main.hs
+++ b/executable/Main.hs
@@ -245,7 +245,7 @@ data ShannonSwitchingGameCG = ShannonSwitchingGameCG {
 instance PositionalGame ShannonSwitchingGameCG (Int, Int) where
   positions ShannonSwitchingGameCG{ graph } = coloredGraphEdgePositions graph
   getPosition ShannonSwitchingGameCG{ graph } = coloredGraphGetEdgePosition graph
-  setPosition ssg@ShannonSwitchingGameCG{ graph } c p = coloredGraphSetBidirectedEdgePosition (\g -> ssg{ graph = g }) graph c (Just p)
+  setPosition ssg@ShannonSwitchingGameCG{ graph } c p = (\g -> ssg{ graph = g }) <$> coloredGraphSetBidirectedEdgePosition graph c (Just p)
   gameOver ShannonSwitchingGameCG{ start, goal, graph } =
       ifNotThen (player1WinsIf winPath) (player1LosesIf losePath) graph
     where
@@ -405,7 +405,7 @@ instance ColoredGraphTransformer (Int, Int) (Maybe Player) (Int, Int) Hex where
 instance PositionalGame Hex (Int, Int) where
   positions (Hex _ b) = values b
   getPosition (Hex _ b) = coloredGraphGetVertexPosition b
-  setPosition (Hex n b) c p = coloredGraphSetVertexPosition (Hex n) b c (Just p)
+  setPosition (Hex n b) c p = Hex n <$> coloredGraphSetVertexPosition b c (Just p)
   gameOver (Hex n b) = criterion b
     where
       criterion =
@@ -433,7 +433,7 @@ instance Show Havannah where
 instance PositionalGame Havannah (Int, Int) where
   positions (Havannah b) = values b
   getPosition (Havannah b) = coloredGraphGetVertexPosition b
-  setPosition (Havannah b) c p = coloredGraphSetVertexPosition Havannah b c (Just p)
+  setPosition (Havannah b) c p = Havannah <$> coloredGraphSetVertexPosition b c (Just p)
   gameOver (Havannah b) = criterion b
     where
       criterion =
@@ -469,7 +469,7 @@ instance Show Yavalath where
 instance PositionalGame Yavalath (Int, Int) where
   positions (Yavalath b) = values b
   getPosition (Yavalath b) = coloredGraphGetVertexPosition b
-  setPosition (Yavalath b) c p = coloredGraphSetVertexPosition Yavalath b c (Just p)
+  setPosition (Yavalath b) c p = Yavalath <$> coloredGraphSetVertexPosition b c (Just p)
   gameOver (Yavalath b) = criterion b
     where
       criterion =
@@ -513,7 +513,7 @@ instance ColoredGraphTransformer (Int, Int) (Maybe Player) String MNKGame where
 instance PositionalGame MNKGame (Int, Int) where
   positions (MNKGame _ b) = values b
   getPosition (MNKGame _ b) = coloredGraphGetVertexPosition b
-  setPosition (MNKGame n b) c p = coloredGraphSetVertexPosition (MNKGame n) b c (Just p)
+  setPosition (MNKGame n b) c p = MNKGame n <$> coloredGraphSetVertexPosition b c (Just p)
   gameOver (MNKGame k b) = criterion b
     where
       criterion =

--- a/executable/Main.hs
+++ b/executable/Main.hs
@@ -68,7 +68,8 @@ import Math.Geometry.Grid as Grid ()
 import Math.Geometry.Grid.Hexagonal ()
 import ColoredGraph (
     ColoredGraph
-  , ColoredGraphVerticesPositionalGame(..)
+  , ColoredGraphTransformer(..)
+  , ColoredGraphVerticesPositionalGame
   , paraHexGraph
   , values
   , anyConnections
@@ -398,9 +399,11 @@ gridShowLine (Hex n b) y  = [rowOffset ++ tileTop ++ [x | y/=0, x <- " /"]
   rowOffset = replicate (2*(hexSize-y-1)) ' '
   tileTop = concat $ replicate hexSize " / \\"
 
-instance ColoredGraphVerticesPositionalGame (Int, Int) Player (Int, Int) Hex where
+instance ColoredGraphTransformer (Int, Int) Player (Int, Int) Hex where
   toColoredGraph (Hex n b) = b
   fromColoredGraph (Hex n _) = Hex n
+
+instance ColoredGraphVerticesPositionalGame (Int, Int) Player (Int, Int) Hex
 
 instance PositionalGame Hex (Int, Int) where
   gameOver (Hex n b) = criterion b
@@ -422,7 +425,7 @@ instance PositionalGame Hex (Int, Int) where
 -------------------------------------------------------------------------------
 
 newtype Havannah = Havannah (ColoredGraph (Int, Int) (Maybe Player) ())
-  deriving (ColoredGraphVerticesPositionalGame (Int, Int) Player ())
+  deriving (ColoredGraphTransformer (Int, Int) Player (), ColoredGraphVerticesPositionalGame (Int, Int) Player ())
 
 instance Show Havannah where
   show (Havannah b) = show b
@@ -455,7 +458,7 @@ emptyHavannah = Havannah . mapEdges (const ()) . hexHexGraph
 -------------------------------------------------------------------------------
 
 newtype Yavalath = Yavalath (ColoredGraph (Int, Int) (Maybe Player) String)
-  deriving (ColoredGraphVerticesPositionalGame (Int, Int) Player String)
+  deriving (ColoredGraphTransformer (Int, Int) Player String, ColoredGraphVerticesPositionalGame (Int, Int) Player String)
 
 instance Show Yavalath where
   show (Yavalath b) = show b
@@ -497,9 +500,11 @@ data MNKGame = MNKGame Int (ColoredGraph (Int, Int) (Maybe Player) String)
 instance Show MNKGame where
   show (MNKGame k b) = show b
 
-instance ColoredGraphVerticesPositionalGame (Int, Int) Player String MNKGame where
+instance ColoredGraphTransformer (Int, Int) Player String MNKGame where
   toColoredGraph (MNKGame n b) = b
   fromColoredGraph (MNKGame n _) = MNKGame n
+
+instance ColoredGraphVerticesPositionalGame (Int, Int) Player String MNKGame
 
 instance PositionalGame MNKGame (Int, Int) where
   gameOver (MNKGame k b) = criterion b

--- a/executable/Main.hs
+++ b/executable/Main.hs
@@ -69,7 +69,6 @@ import Math.Geometry.Grid.Hexagonal ()
 import ColoredGraph (
     ColoredGraph
   , ColoredGraphTransformer(..)
-  , ColoredGraphVerticesPositionalGame
   , paraHexGraph
   , values
   , anyConnections
@@ -82,6 +81,8 @@ import ColoredGraph (
   , mapEdges
   , rectOctGraph
   , inARow
+  , coloredGraphGetVertexPosition
+  , coloredGraphSetVertexPosition
   , coloredGraphEdgePositions
   , coloredGraphGetEdgePosition
   , coloredGraphSetBidirectedEdgePosition
@@ -401,9 +402,10 @@ instance ColoredGraphTransformer (Int, Int) (Maybe Player) (Int, Int) Hex where
   toColoredGraph (Hex n b) = b
   fromColoredGraph (Hex n _) = Hex n
 
-instance ColoredGraphVerticesPositionalGame (Int, Int) (Maybe Player) (Int, Int) Hex
-
 instance PositionalGame Hex (Int, Int) where
+  positions (Hex _ b) = values b
+  getPosition (Hex _ b) = coloredGraphGetVertexPosition b
+  setPosition (Hex n b) c p = coloredGraphSetVertexPosition (Hex n) b c (Just p)
   gameOver (Hex n b) = criterion b
     where
       criterion =
@@ -423,12 +425,15 @@ instance PositionalGame Hex (Int, Int) where
 -------------------------------------------------------------------------------
 
 newtype Havannah = Havannah (ColoredGraph (Int, Int) (Maybe Player) ())
-  deriving (ColoredGraphTransformer (Int, Int) (Maybe Player) (), ColoredGraphVerticesPositionalGame (Int, Int) (Maybe Player) ())
+  deriving (ColoredGraphTransformer (Int, Int) (Maybe Player) ())
 
 instance Show Havannah where
   show (Havannah b) = show b
 
 instance PositionalGame Havannah (Int, Int) where
+  positions (Havannah b) = values b
+  getPosition (Havannah b) = coloredGraphGetVertexPosition b
+  setPosition (Havannah b) c p = coloredGraphSetVertexPosition Havannah b c (Just p)
   gameOver (Havannah b) = criterion b
     where
       criterion =
@@ -456,12 +461,15 @@ emptyHavannah = Havannah . mapEdges (const ()) . hexHexGraph
 -------------------------------------------------------------------------------
 
 newtype Yavalath = Yavalath (ColoredGraph (Int, Int) (Maybe Player) String)
-  deriving (ColoredGraphTransformer (Int, Int) (Maybe Player) String, ColoredGraphVerticesPositionalGame (Int, Int) (Maybe Player) String)
+  deriving (ColoredGraphTransformer (Int, Int) (Maybe Player) String)
 
 instance Show Yavalath where
   show (Yavalath b) = show b
 
 instance PositionalGame Yavalath (Int, Int) where
+  positions (Yavalath b) = values b
+  getPosition (Yavalath b) = coloredGraphGetVertexPosition b
+  setPosition (Yavalath b) c p = coloredGraphSetVertexPosition Yavalath b c (Just p)
   gameOver (Yavalath b) = criterion b
     where
       criterion =
@@ -502,9 +510,10 @@ instance ColoredGraphTransformer (Int, Int) (Maybe Player) String MNKGame where
   toColoredGraph (MNKGame n b) = b
   fromColoredGraph (MNKGame n _) = MNKGame n
 
-instance ColoredGraphVerticesPositionalGame (Int, Int) (Maybe Player) String MNKGame
-
 instance PositionalGame MNKGame (Int, Int) where
+  positions (MNKGame _ b) = values b
+  getPosition (MNKGame _ b) = coloredGraphGetVertexPosition b
+  setPosition (MNKGame n b) c p = coloredGraphSetVertexPosition (MNKGame n) b c (Just p)
   gameOver (MNKGame k b) = criterion b
     where
       criterion =

--- a/executable/Main.hs
+++ b/executable/Main.hs
@@ -81,7 +81,11 @@ import ColoredGraph (
   , hexHexGraph
   , mapEdges
   , rectOctGraph
-  , inARow)
+  , inARow
+  , coloredGraphEdgePositions
+  , coloredGraphGetEdgePosition
+  , coloredGraphSetBidirectedEdgePosition
+  )
 -------------------------------------------------------------------------------
 -- * TicTacToe
 -------------------------------------------------------------------------------
@@ -238,15 +242,9 @@ data ShannonSwitchingGameCG = ShannonSwitchingGameCG {
   deriving (Show)
 
 instance PositionalGame ShannonSwitchingGameCG (Int, Int) where
-  positions ShannonSwitchingGameCG{ graph } = elems graph >>= (elems . snd)
-  getPosition ShannonSwitchingGameCG{ graph } (from, to) = lookup from graph >>= (lookup to . snd)
-  setPosition ssg@ShannonSwitchingGameCG{ graph } (from, to) p = lookup from graph >>=
-    (\eg -> if member to $ snd eg
-      then Just $ ssg{
-        graph = adjust (second (insert from (Just p))) to $
-          adjust (second (insert to (Just p))) from graph
-      }
-      else Nothing)
+  positions ShannonSwitchingGameCG{ graph } = coloredGraphEdgePositions graph
+  getPosition ShannonSwitchingGameCG{ graph } = coloredGraphGetEdgePosition graph
+  setPosition ssg@ShannonSwitchingGameCG{ graph } c p = coloredGraphSetBidirectedEdgePosition (\g -> ssg{ graph = g }) graph c (Just p)
   gameOver ShannonSwitchingGameCG{ start, goal, graph } =
       ifNotThen (player1WinsIf winPath) (player1LosesIf losePath) graph
     where

--- a/executable/Main.hs
+++ b/executable/Main.hs
@@ -81,6 +81,7 @@ import ColoredGraph (
   , mapEdges
   , rectOctGraph
   , inARow
+  , coloredGraphVertexPositions
   , coloredGraphGetVertexPosition
   , coloredGraphSetVertexPosition
   , coloredGraphEdgePositions
@@ -407,7 +408,7 @@ instance ColoredGraphTransformer (Int, Int) (Maybe Player) (Int, Int) Hex where
   fromColoredGraph (Hex n _) = Hex n
 
 instance PositionalGame Hex (Int, Int) where
-  positions (Hex _ b) = values b
+  positions = coloredGraphVertexPositions
   getPosition = coloredGraphGetVertexPosition
   setPosition g c p = coloredGraphSetVertexPosition g c (Just p)
   gameOver (Hex n b) = criterion b
@@ -435,7 +436,7 @@ instance Show Havannah where
   show (Havannah b) = show b
 
 instance PositionalGame Havannah (Int, Int) where
-  positions (Havannah b) = values b
+  positions = coloredGraphVertexPositions
   getPosition = coloredGraphGetVertexPosition
   setPosition g c p = coloredGraphSetVertexPosition g c (Just p)
   gameOver (Havannah b) = criterion b
@@ -471,7 +472,7 @@ instance Show Yavalath where
   show (Yavalath b) = show b
 
 instance PositionalGame Yavalath (Int, Int) where
-  positions (Yavalath b) = values b
+  positions = coloredGraphVertexPositions
   getPosition = coloredGraphGetVertexPosition
   setPosition g c p = coloredGraphSetVertexPosition g c (Just p)
   gameOver (Yavalath b) = criterion b
@@ -515,7 +516,7 @@ instance ColoredGraphTransformer (Int, Int) (Maybe Player) String MNKGame where
   fromColoredGraph (MNKGame n _) = MNKGame n
 
 instance PositionalGame MNKGame (Int, Int) where
-  positions (MNKGame _ b) = values b
+  positions = coloredGraphVertexPositions
   getPosition = coloredGraphGetVertexPosition
   setPosition g c p = coloredGraphSetVertexPosition g c (Just p)
   gameOver (MNKGame k b) = criterion b

--- a/src/ColoredGraph.hs
+++ b/src/ColoredGraph.hs
@@ -17,6 +17,7 @@ module ColoredGraph (
   , anyConnections
   , inARow
   , values
+  , coloredGraphVertexPositions
   , coloredGraphSetVertexPosition
   , coloredGraphGetVertexPosition
   , coloredGraphEdgePositions
@@ -32,6 +33,7 @@ import qualified Data.Set as Set
 import Data.List ( find, intersect )
 import Data.Maybe ( fromJust, isJust, listToMaybe, mapMaybe )
 import Data.Tree ()
+import Control.Monad ((<=<))
 import Data.Bifunctor ( bimap, Bifunctor (first, second) )
 
 
@@ -236,6 +238,13 @@ anyConnections pred groups g = any (\z -> pred $ length $ filter (not . Prelude.
 inARow :: (Ord i, Eq b) => (Int -> Bool) -> b -> ColoredGraph i a b -> Bool
 inARow pred dir = any (pred . length) . components . filterEdges (==dir)
 
+-- | A standard implementation of 'MyLib.positions' for games
+--   with an underlying 'ColoredGraph' played on the vertices.
+--
+--   For 'ColoredGraph's, this is a synonym of 'values'.
+coloredGraphVertexPositions :: (ColoredGraphTransformer i a b g, Ord i) => g -> [a]
+coloredGraphVertexPositions = values . toColoredGraph
+
 -- | A standard implementation of 'MyLib.getPosition' for games
 --   with an underlying 'ColoredGraph' played on the vertices.
 coloredGraphGetVertexPosition :: (ColoredGraphTransformer i a b g, Ord i) => g -> i -> Maybe a
@@ -253,7 +262,7 @@ coloredGraphSetVertexPosition g i p = if Map.member i c
 -- | A standard implementation of 'MyLib.positions' for games
 --   with an underlying 'ColoredGraph' played on the edges.
 coloredGraphEdgePositions :: (ColoredGraphTransformer i a b g, Ord i) => g -> [b]
-coloredGraphEdgePositions g = Map.elems (toColoredGraph g) >>= (Map.elems . snd)
+coloredGraphEdgePositions = Map.elems . snd <=< Map.elems . toColoredGraph
 
 -- | A standard implementation of 'MyLib.getPosition' for games
 --   with an underlying 'ColoredGraph' played on the edges.

--- a/src/ColoredGraph.hs
+++ b/src/ColoredGraph.hs
@@ -4,7 +4,8 @@
 
 module ColoredGraph (
     ColoredGraph
-  , ColoredGraphVerticesPositionalGame(..)
+  , ColoredGraphTransformer(..)
+  , ColoredGraphVerticesPositionalGame
   , hexHexGraph
   , paraHexGraph
   , rectOctGraph
@@ -244,19 +245,24 @@ coloredGraphSetVertexPosition constructor c i p = if Map.member i c
     then Just $ constructor $ Map.adjust (\(_, xs) -> (Just p, xs)) i c
     else Nothing
 
--- | A class for games based on 'ColoredGraph's that allows them to use default
---   implementations of functions in 'MyLib.PositionalGame'. Game of the class
---   are played on the vertices of of the graph.
+-- | A utility class for transforming to and from 'ColoredGraph'.
 --
 --   New-types of 'ColoredGraph' can derive this using the
 --   'GeneralizedNewtypeDeriving' language extension.
-class ColoredGraphVerticesPositionalGame i a b g | g -> i, g -> a, g -> b where
+class ColoredGraphTransformer i a b g | g -> i, g -> a, g -> b where
+  -- | "Extracts" the 'ColoredGraph' from a container type.
   toColoredGraph :: g -> ColoredGraph i (Maybe a) b
+  -- | "Inserts" the 'ColoredGraph' into an already existing container type.
   fromColoredGraph :: g -> ColoredGraph i (Maybe a) b -> g
 
-instance ColoredGraphVerticesPositionalGame i a b (ColoredGraph i (Maybe a) b) where
+instance ColoredGraphTransformer i a b (ColoredGraph i (Maybe a) b) where
   toColoredGraph c = c
   fromColoredGraph _ = id
+
+-- | A class for games based on 'ColoredGraph's that allows them to use default
+--   implementations of functions in 'MyLib.PositionalGame'. Game of the class
+--   are played on the vertices of of the graph.
+class (ColoredGraphTransformer i a b g) => ColoredGraphVerticesPositionalGame i a b g | g -> i, g -> a, g -> b where
 
 
 

--- a/src/ColoredGraph.hs
+++ b/src/ColoredGraph.hs
@@ -243,9 +243,9 @@ coloredGraphGetVertexPosition c i = fst <$> Map.lookup i c
 
 -- | A standard implementation of 'MyLib.setPosition' for games
 --   with an underlying 'ColoredGraph' played on the vertices.
-coloredGraphSetVertexPosition :: Ord i => (ColoredGraph i a b -> c) -> ColoredGraph i a b -> i -> a -> Maybe c
-coloredGraphSetVertexPosition constructor c i p = if Map.member i c
-    then Just $ constructor $ Map.adjust (\(_, xs) -> (p, xs)) i c
+coloredGraphSetVertexPosition :: Ord i => ColoredGraph i a b -> i -> a -> Maybe (ColoredGraph i a b)
+coloredGraphSetVertexPosition c i p = if Map.member i c
+    then Just $ Map.adjust (\(_, xs) -> (p, xs)) i c
     else Nothing
 
 -- | A standard implementation of 'MyLib.positions' for games
@@ -260,23 +260,17 @@ coloredGraphGetEdgePosition c (from, to) = Map.lookup from c >>= (Map.lookup to 
 
 -- | A standard implementation of 'MyLib.setPosition' for games
 --   with an underlying 'ColoredGraph' played on the vertices.
-coloredGraphSetEdgePosition :: Ord i => (ColoredGraph i a b -> c) -> ColoredGraph i a b -> (i, i) -> b -> Maybe c
-coloredGraphSetEdgePosition constructor c (from, to) p = Map.lookup from c >>=
+coloredGraphSetEdgePosition :: Ord i => ColoredGraph i a b -> (i, i) -> b -> Maybe (ColoredGraph i a b)
+coloredGraphSetEdgePosition c (from, to) p = Map.lookup from c >>=
   \(a, edges) -> if Map.member to edges
-    then Just $ constructor $ Map.insert from (a, Map.insert to p edges) c
+    then Just $ Map.insert from (a, Map.insert to p edges) c
     else Nothing
 
 -- | Like 'coloredGraphSetEdgePosition' but sets the value to the edges in both
 --   directions.
-coloredGraphSetBidirectedEdgePosition :: Ord i => (ColoredGraph i a b -> c) -> ColoredGraph i a b -> (i, i) -> b -> Maybe c
-coloredGraphSetBidirectedEdgePosition constructor c (from, to) p = Map.lookup from c >>=
-  (\(a, edges) -> if Map.member to edges
-    then Just $ Map.insert from (a, Map.insert to p edges) c
-    else Nothing) >>=
-  \c' -> Map.lookup to c' >>=
-    \(a, edges) -> if Map.member from edges
-      then Just $ constructor $ Map.insert to (a, Map.insert from p edges) c'
-      else Nothing
+coloredGraphSetBidirectedEdgePosition :: Ord i => ColoredGraph i a b -> (i, i) -> b -> Maybe (ColoredGraph i a b)
+coloredGraphSetBidirectedEdgePosition c (from, to) p = coloredGraphSetEdgePosition c (from, to) p >>=
+  \c' -> coloredGraphSetEdgePosition c' (to, from) p
 
 -- | A utility class for transforming to and from 'ColoredGraph'.
 --

--- a/src/ColoredGraph.hs
+++ b/src/ColoredGraph.hs
@@ -5,8 +5,6 @@
 module ColoredGraph (
     ColoredGraph
   , ColoredGraphTransformer(..)
-  , ColoredGraphVerticesPositionalGame
-  , ColoredGraphEdgesPositionalGame
   , hexHexGraph
   , paraHexGraph
   , rectOctGraph
@@ -294,15 +292,6 @@ instance ColoredGraphTransformer i a b (ColoredGraph i a b) where
   toColoredGraph c = c
   fromColoredGraph _ = id
 
--- | A class for games based on 'ColoredGraph's that allows them to use default
---   implementations of functions in 'MyLib.PositionalGame'. Game of the class
---   are played on the vertices of of the graph.
-class (ColoredGraphTransformer i a b g) => ColoredGraphVerticesPositionalGame i a b g | g -> i, g -> a, g -> b where
-
--- | A class for games based on 'ColoredGraph's that allows them to use default
---   implementations of functions in 'MyLib.PositionalGame'. Game of the class
---   are played on the edges of of the graph.
-class (ColoredGraphTransformer i a b g) => ColoredGraphEdgesPositionalGame i a b g | g -> i, g -> a, g -> b where
 
 
 

--- a/src/ColoredGraph.hs
+++ b/src/ColoredGraph.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 module ColoredGraph (
     ColoredGraph
@@ -252,9 +253,9 @@ coloredGraphGetVertexPosition g i = fst <$> Map.lookup i (toColoredGraph g)
 
 -- | A standard implementation of 'MyLib.setPosition' for games
 --   with an underlying 'ColoredGraph' played on the vertices.
-coloredGraphSetVertexPosition :: (ColoredGraphTransformer i a b g, Ord i) => g -> i -> a -> Maybe g
+coloredGraphSetVertexPosition :: (ColoredGraphTransformer i (Maybe a) b g, Ord i) => g -> i -> a -> Maybe g
 coloredGraphSetVertexPosition g i p = if Map.member i c
-    then Just $ fromColoredGraph g $ Map.adjust (\(_, xs) -> (p, xs)) i c
+    then Just $ fromColoredGraph g $ Map.adjust (\(_, xs) -> (Just p, xs)) i c
     else Nothing
   where
     c = toColoredGraph g
@@ -271,17 +272,17 @@ coloredGraphGetEdgePosition g (from, to) = Map.lookup from (toColoredGraph g) >>
 
 -- | A standard implementation of 'MyLib.setPosition' for games
 --   with an underlying 'ColoredGraph' played on the vertices.
-coloredGraphSetEdgePosition :: (ColoredGraphTransformer i a b g, Ord i) => g -> (i, i) -> b -> Maybe g
+coloredGraphSetEdgePosition :: (ColoredGraphTransformer i a (Maybe b) g, Ord i) => g -> (i, i) -> b -> Maybe g
 coloredGraphSetEdgePosition g (from, to) p = Map.lookup from c >>=
     \(a, edges) -> if Map.member to edges
-      then Just $ fromColoredGraph g $ Map.insert from (a, Map.insert to p edges) c
+      then Just $ fromColoredGraph g $ Map.insert from (a, Map.insert to (Just p) edges) c
       else Nothing
   where
     c = toColoredGraph g
 
 -- | Like 'coloredGraphSetEdgePosition' but sets the value to the edges in both
 --   directions.
-coloredGraphSetBidirectedEdgePosition :: (ColoredGraphTransformer i a b g, Ord i) => g -> (i, i) -> b -> Maybe g
+coloredGraphSetBidirectedEdgePosition :: (ColoredGraphTransformer i a (Maybe b) g, Ord i) => g -> (i, i) -> b -> Maybe g
 coloredGraphSetBidirectedEdgePosition c (from, to) p = coloredGraphSetEdgePosition c (from, to) p >>=
   \c' -> coloredGraphSetEdgePosition c' (to, from) p
 

--- a/src/ColoredGraph.hs
+++ b/src/ColoredGraph.hs
@@ -235,14 +235,14 @@ inARow pred dir = any (pred . length) . components . filterEdges (==dir)
 
 -- | A standard implementation of 'MyLib.getPosition' for games
 --   with an underlying 'ColoredGraph' played on the vertices.
-coloredGraphGetVertexPosition :: Ord i => ColoredGraph i (Maybe a) b -> i -> Maybe (Maybe a)
+coloredGraphGetVertexPosition :: Ord i => ColoredGraph i a b -> i -> Maybe a
 coloredGraphGetVertexPosition c i = fst <$> Map.lookup i c
 
 -- | A standard implementation of 'MyLib.setPosition' for games
 --   with an underlying 'ColoredGraph' played on the vertices.
-coloredGraphSetVertexPosition :: Ord i => (ColoredGraph i (Maybe a) b -> c) -> ColoredGraph i (Maybe a) b -> i -> a -> Maybe c
+coloredGraphSetVertexPosition :: Ord i => (ColoredGraph i a b -> c) -> ColoredGraph i a b -> i -> a -> Maybe c
 coloredGraphSetVertexPosition constructor c i p = if Map.member i c
-    then Just $ constructor $ Map.adjust (\(_, xs) -> (Just p, xs)) i c
+    then Just $ constructor $ Map.adjust (\(_, xs) -> (p, xs)) i c
     else Nothing
 
 -- | A utility class for transforming to and from 'ColoredGraph'.
@@ -251,11 +251,11 @@ coloredGraphSetVertexPosition constructor c i p = if Map.member i c
 --   'GeneralizedNewtypeDeriving' language extension.
 class ColoredGraphTransformer i a b g | g -> i, g -> a, g -> b where
   -- | "Extracts" the 'ColoredGraph' from a container type.
-  toColoredGraph :: g -> ColoredGraph i (Maybe a) b
+  toColoredGraph :: g -> ColoredGraph i a b
   -- | "Inserts" the 'ColoredGraph' into an already existing container type.
-  fromColoredGraph :: g -> ColoredGraph i (Maybe a) b -> g
+  fromColoredGraph :: g -> ColoredGraph i a b -> g
 
-instance ColoredGraphTransformer i a b (ColoredGraph i (Maybe a) b) where
+instance ColoredGraphTransformer i a b (ColoredGraph i a b) where
   toColoredGraph c = c
   fromColoredGraph _ = id
 

--- a/src/MyLib.hs
+++ b/src/MyLib.hs
@@ -80,7 +80,7 @@ class PositionalGame a c | a -> c where
   gameOver :: a -> Maybe (Maybe Player)
   -- | Returns a list of all positions. Not in any particular order.
   positions :: a -> [Maybe Player]
-  default positions :: (ColoredGraphVerticesPositionalGame c Player e a) => a -> [Maybe Player]
+  default positions :: (ColoredGraphVerticesPositionalGame c (Maybe Player) e a) => a -> [Maybe Player]
   positions = values . toColoredGraph
   -- | Returns which player (or nothing) has taken the position at the given
   --   coordinate, or 'Nothing' if the given coordinate is invalid.
@@ -89,13 +89,13 @@ class PositionalGame a c | a -> c where
   -- > Just (Just p) -- Player p owns this position
   -- > Just Nothing  -- This position is empty
   getPosition :: a -> c -> Maybe (Maybe Player)
-  default getPosition :: (ColoredGraphVerticesPositionalGame c Player e a, Ord c) => a -> c -> Maybe (Maybe Player)
+  default getPosition :: (ColoredGraphVerticesPositionalGame c (Maybe Player) e a, Ord c) => a -> c -> Maybe (Maybe Player)
   getPosition = coloredGraphGetVertexPosition . toColoredGraph
   -- | Takes the position at the given coordinate for the given player and
   --   returns the new state, or 'Nothing' if the given coordinate is invalid.
   setPosition :: a -> c -> Player -> Maybe a
-  default setPosition :: (ColoredGraphVerticesPositionalGame c Player e a, Ord c) => a -> c -> Player -> Maybe a
-  setPosition g = coloredGraphSetVertexPosition (fromColoredGraph g) $ toColoredGraph g
+  default setPosition :: (ColoredGraphVerticesPositionalGame c (Maybe Player) e a, Ord c) => a -> c -> Player -> Maybe a
+  setPosition g c p = coloredGraphSetVertexPosition (fromColoredGraph g) (toColoredGraph g) c (Just p)
 
 -- | A standard implementation of 'makeMove' for a 'PositionalGame'.
 --   Only allows move that "take" empty existing positions.

--- a/src/MyLib.hs
+++ b/src/MyLib.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleContexts #-}
 
 module MyLib (
@@ -31,13 +30,6 @@ import System.IO (hFlush, stdout)
 import Text.Read (readMaybe)
 import Control.Monad (join, foldM)
 import Control.Applicative ((<|>))
-import ColoredGraph (
-    ColoredGraphTransformer(..)
-  , ColoredGraphVerticesPositionalGame
-  , values
-  , coloredGraphGetVertexPosition
-  , coloredGraphSetVertexPosition
-  )
 #ifdef WASM
 import Data.Aeson (ToJSON(toJSON), Value(Number))
 import Data.Scientific (fromFloatDigits)
@@ -80,8 +72,6 @@ class PositionalGame a c | a -> c where
   gameOver :: a -> Maybe (Maybe Player)
   -- | Returns a list of all positions. Not in any particular order.
   positions :: a -> [Maybe Player]
-  default positions :: (ColoredGraphVerticesPositionalGame c (Maybe Player) e a) => a -> [Maybe Player]
-  positions = values . toColoredGraph
   -- | Returns which player (or nothing) has taken the position at the given
   --   coordinate, or 'Nothing' if the given coordinate is invalid.
   --
@@ -89,13 +79,9 @@ class PositionalGame a c | a -> c where
   -- > Just (Just p) -- Player p owns this position
   -- > Just Nothing  -- This position is empty
   getPosition :: a -> c -> Maybe (Maybe Player)
-  default getPosition :: (ColoredGraphVerticesPositionalGame c (Maybe Player) e a, Ord c) => a -> c -> Maybe (Maybe Player)
-  getPosition = coloredGraphGetVertexPosition . toColoredGraph
   -- | Takes the position at the given coordinate for the given player and
   --   returns the new state, or 'Nothing' if the given coordinate is invalid.
   setPosition :: a -> c -> Player -> Maybe a
-  default setPosition :: (ColoredGraphVerticesPositionalGame c (Maybe Player) e a, Ord c) => a -> c -> Player -> Maybe a
-  setPosition g c p = coloredGraphSetVertexPosition (fromColoredGraph g) (toColoredGraph g) c (Just p)
 
 -- | A standard implementation of 'makeMove' for a 'PositionalGame'.
 --   Only allows move that "take" empty existing positions.

--- a/src/MyLib.hs
+++ b/src/MyLib.hs
@@ -32,7 +32,8 @@ import Text.Read (readMaybe)
 import Control.Monad (join, foldM)
 import Control.Applicative ((<|>))
 import ColoredGraph (
-    ColoredGraphVerticesPositionalGame(..)
+    ColoredGraphTransformer(..)
+  , ColoredGraphVerticesPositionalGame
   , values
   , coloredGraphGetVertexPosition
   , coloredGraphSetVertexPosition


### PR DESCRIPTION
This PR adds a Shannon Switching Game written using a `ColoredGraph` and all the fancy helper functions. To make it even easier to write games using `ColoredGraph` that are played on the vertices of the graph, a set of new helper functions has been created. The new functions correspond to the helper functions from #2.

Multiple default implementations couldn't be added to the `PositionalGame` class. So, the existing ones for `ColoredGraph` games played on the edges has been removed. Users now must define these themselves, but the can in most cases be equal to one of the provided helper functions.

A problem I encountered during development was that `setPosition` expected a `Maybe Player` but `ColoredGraph` had no knowledge of if the values on the edges/vertices where `Maybe` or not. I saw two solutions to this, either narrow the constraints for the affected helper functions so that the only work on `Maybe a`/`Maybe b`, or generalize the `setPosition` argument to `Player`.

I've opened one PR for each solution and want your opinion. This PR represents the first alternative and #6 represents the other, accept one of them.