### PR TITLE
Multiple web

### DIFF
--- a/executable/Main.hs
+++ b/executable/Main.hs
@@ -56,7 +56,7 @@ import Data.Foldable (toList)
 import qualified Data.Vector as V ((!), fromList)
 import Data.Aeson
 import Data.Aeson.Types
-import MyLib.Web (webDefaultMain)
+import MyLib.Web (defaultWebGame)
 #endif
 
 import Math.Geometry.Grid as Grid ()
@@ -466,7 +466,7 @@ emptyMNKGame m n k = MNKGame k $ mapEdges dirName $ rectOctGraph m n
 
 #ifdef WASM
 main :: IO ()
-main = webDefaultMain $ emptyHex 5
+main = defaultWebGame $ emptyHex 5
 #else
 main :: IO ()
 main = do

--- a/executable/Main.hs
+++ b/executable/Main.hs
@@ -56,7 +56,7 @@ import Data.Foldable (toList)
 import qualified Data.Vector as V ((!), fromList)
 import Data.Aeson
 import Data.Aeson.Types
-import MyLib.Web (defaultWebGame)
+import MyLib.Web (addWebGame, webReady)
 #endif
 
 import Math.Geometry.Grid as Grid ()
@@ -428,6 +428,11 @@ data MNKGame = MNKGame Int (ColoredGraph (Int, Int) (Maybe Player) String)
 instance Show MNKGame where
   show (MNKGame k b) = show b
 
+#if WASM
+instance ToJSON MNKGame where
+  toJSON (MNKGame _ b) = toJSON b
+#endif
+
 instance ColoredGraphVerticesPositionalGame (Int, Int) Player String MNKGame where
   toColoredGraph (MNKGame n b) = b
   fromColoredGraph (MNKGame n _) = MNKGame n
@@ -466,7 +471,10 @@ emptyMNKGame m n k = MNKGame k $ mapEdges dirName $ rectOctGraph m n
 
 #ifdef WASM
 main :: IO ()
-main = defaultWebGame $ emptyHex 5
+main = do
+  addWebGame "TicTacToe" $ emptyMNKGame 3 3 3
+  addWebGame "Hex" $ emptyHex 5
+  webReady
 #else
 main :: IO ()
 main = do

--- a/src/MyLib/Web.hs
+++ b/src/MyLib/Web.hs
@@ -2,7 +2,7 @@
 
 module MyLib.Web (
     playWeb
-  , webDefaultMain
+  , defaultWebGame
 ) where
 
 import Asterius.Aeson (jsonFromJSVal, jsonToJSVal)
@@ -24,15 +24,16 @@ foreign import javascript safe "boardgame._getMove()" jsGetMove :: IO JSVal
 foreign import javascript "boardgame._putInvalidInput()" jsPutInvalidInput :: IO ()
 foreign import javascript "boardgame._putInvalidMove()" jsPutInvalidMove :: IO ()
 foreign import javascript "boardgame._putGameOver($1)" jsPutGameOver :: JSVal -> IO ()
-foreign import javascript "boardgame.startGame = $1" jsSetGame :: JSVal -> IO ()
+foreign import javascript "boardgame.games[$1] = $2" jsSetGame :: JSVal -> JSVal -> IO ()
 foreign import javascript "boardgame._ready()" jsReady :: IO ()
 
--- | A main function for running games as a we app. Initializes the game and
---   "tells" JavaScript it's ready. Then JavaScript can start games whenever.
-webDefaultMain :: (ToJSON a, FromJSON c, PositionalGame a c) => a -> IO ()
-webDefaultMain startState = do
+-- | A main function for running games as a web app. Initializes the provided
+--   game as "default" and "tells" JavaScript it's ready. Then JavaScript can
+--   start games whenever.
+defaultWebGame :: (ToJSON a, FromJSON c, PositionalGame a c) => a -> IO ()
+defaultWebGame startState = do
   callback <- jsMakeCallback $ playWeb startState
-  jsSetGame callback
+  jsSetGame (jsonToJSVal "default") callback
   jsReady
 
 -- | Plays a 'PositionalGame' with the help of JavaScript FFI. The state of the

--- a/src/MyLib/Web.hs
+++ b/src/MyLib/Web.hs
@@ -3,6 +3,8 @@
 module MyLib.Web (
     playWeb
   , defaultWebGame
+  , addWebGame
+  , webReady
 ) where
 
 import Asterius.Aeson (jsonFromJSVal, jsonToJSVal)
@@ -35,6 +37,17 @@ defaultWebGame startState = do
   callback <- jsMakeCallback $ playWeb startState
   jsSetGame (jsonToJSVal "default") callback
   jsReady
+
+-- | Adds a named game to the list of games accessible from JavaScript.
+addWebGame :: (ToJSON a, FromJSON c, PositionalGame a c) => String -> a -> IO ()
+addWebGame name startState = do
+  callback <- jsMakeCallback $ playWeb startState
+  jsSetGame (jsonToJSVal name) callback
+
+-- | Lets JavaScript know that the Haskell backend is up and running by firing
+--   the ready event.
+webReady :: IO ()
+webReady = jsReady
 
 -- | Plays a 'PositionalGame' with the help of JavaScript FFI. The state of the
 --   game ('a') needs to implement 'Data.Aeson.ToJSON' and the coordinates


### PR DESCRIPTION
The communication between Haskell and JavaScript now allows for multiple games. This works by replacing the old `startGame` JavaScript function with a map from names to functions. JavaScript can then call one of the functions in the map to start the corresponding game. Only one game can be played at a time, and when starting a new game any currently running game will be abandoned.

This PR is accompanied by a PR to the JavaScript side, Boardgame-DSL/boardgame.js#1.