### PR TITLE
Removing maybe maybes

### DIFF
--- a/executable/Main.hs
+++ b/executable/Main.hs
@@ -36,6 +36,7 @@ import Data.Maybe (fromJust, isJust, fromMaybe, mapMaybe)
 import Boardgame (
     Player(..)
   , Position(..)
+  , Outcome(..)
   , PositionalGame(..)
   , mapPosition
   , isOccupied
@@ -231,9 +232,9 @@ instance PositionalGame ShannonSwitchingGame (Int, Int) where
     Just i -> Just $ ShannonSwitchingGame (n, take i l ++ (c, p) : drop (i + 1) l)
     Nothing -> Nothing
   gameOver (ShannonSwitchingGame (n, l))
-    | path g 0 (n * n - 1) = Just (Just Player1)
-    | path g (n - 1) (n * n - n) = Just (Just Player2)
-    | all (isOccupied . snd) l = Just Nothing
+    | path g 0 (n * n - 1) = Just $ Win Player1
+    | path g (n - 1) (n * n - n) = Just $ Win Player2
+    | all (isOccupied . snd) l = Just Draw
     | otherwise = Nothing
     where
       g = buildG (0, n * n - 1) (map fst $ filter ((== Occupied Player1) . snd) l)
@@ -359,9 +360,9 @@ instance PositionalGame Gale (Integer, Integer) where
   setPosition (Gale b) (x, y) p = if x `rem` 2 == y `rem` 2 && member c b then Just $ Gale $ insert c p b else Nothing
     where c = (x `div` 2, y)
   gameOver (Gale b)
-    | path player1Graph (-1) (-2) = Just $ Just Player1
-    | path player2Graph (-1) (-2) = Just $ Just Player2
-    | all isOccupied (elems b) = Just Nothing
+    | path player1Graph (-1) (-2) = Just $ Win Player1
+    | path player2Graph (-1) (-2) = Just $ Win Player2
+    | all isOccupied (elems b) = Just Draw
     | otherwise            = Nothing
     where
       playerGraph from to p = buildG (-2, 19) $

--- a/executable/Main.hs
+++ b/executable/Main.hs
@@ -35,7 +35,10 @@ import Data.Map (
 import Data.Maybe (fromJust, isJust, fromMaybe, mapMaybe)
 import Boardgame (
     Player(..)
+  , Position(..)
   , PositionalGame(..)
+  , mapPosition
+  , isOccupied
   , patternMatchingGameOver
   , playIO
   , takeEmptyMakeMove
@@ -100,7 +103,7 @@ import Data.Tree (Tree, foldTree)
 -- * TicTacToe
 -------------------------------------------------------------------------------
 
-newtype TicTacToe = TicTacToe (Map (Integer, Integer) (Maybe Player))
+newtype TicTacToe = TicTacToe (Map (Integer, Integer) Position)
 
 -- Creates an empty TicTacToe board with coordinates `(0..2, 0..2)`
 emptyTicTacToe :: TicTacToe
@@ -108,7 +111,7 @@ emptyTicTacToe = TicTacToe $
   fromDistinctAscList $
     zip
       [(x, y) | x <- [0..2], y <- [0..2]]
-      (repeat Nothing)
+      (repeat Empty)
 
 instance Show TicTacToe where
   show (TicTacToe b) = intercalate "\n" [
@@ -123,9 +126,9 @@ instance Show TicTacToe where
     where
       -- "Shows" the elements of the given row
       row y = map (\x -> showP $ b ! (x, y)) [0..2]
-      showP (Just Player1) = "\ESC[34mo\ESC[0m"
-      showP (Just Player2) = "\ESC[31mx\ESC[0m"
-      showP Nothing = " "
+      showP (Occupied Player1) = "\ESC[34mo\ESC[0m"
+      showP (Occupied Player2) = "\ESC[31mx\ESC[0m"
+      showP Empty = " "
 
 #ifdef WASM
 -- Converts the game to a JSON array with three arrays with three integers
@@ -136,10 +139,7 @@ instance Show TicTacToe where
 instance ToJSON TicTacToe where
   toJSON (TicTacToe b) = Array $ V.fromList $ map row [0..2]
     where
-      row y = Array $ V.fromList $ map (\x -> toJSONP $ b ! (x, y)) [0..2]
-      toJSONP (Just Player1) = toJSON (1 :: Int)
-      toJSONP (Just Player2) = toJSON (2 :: Int)
-      toJSONP Nothing = toJSON (0 :: Int)
+      row y = Array $ V.fromList $ map (\x -> toJSON $ b ! (x, y)) [0..2]
 #endif
 
 instance PositionalGame TicTacToe (Integer, Integer) where
@@ -165,20 +165,20 @@ instance PositionalGame TicTacToe (Integer, Integer) where
 -- * Arithmetic Progression Game
 -------------------------------------------------------------------------------
 
-data ArithmeticProgressionGame = ArithmeticProgressionGame Int [Maybe Player]
+data ArithmeticProgressionGame = ArithmeticProgressionGame Int [Position]
 
 createArithmeticProgressionGame :: Int -> Int -> Maybe ArithmeticProgressionGame
 createArithmeticProgressionGame n k = if k < n
-  then Just $ ArithmeticProgressionGame k (replicate n Nothing)
+  then Just $ ArithmeticProgressionGame k (replicate n Empty)
   else Nothing
 
 instance Show ArithmeticProgressionGame where
   show (ArithmeticProgressionGame _ ps) = (\(is, ps) -> intercalate "," is ++ "\n" ++ intercalate "," ps) $
         unzip $ zipWith (\i p -> (pad $ show i, pad $ showP p)) [1..] ps
     where
-      showP Nothing        = "  _"
-      showP (Just Player1) = "  \ESC[34mO\ESC[0m"
-      showP (Just Player2) = "  \ESC[31mX\ESC[0m"
+      showP Empty           = "  _"
+      showP (Occupied Player1) = "  \ESC[34mO\ESC[0m"
+      showP (Occupied Player2) = "  \ESC[31mX\ESC[0m"
       pad x = replicate (3 - length x) ' ' ++ x
 
 instance PositionalGame ArithmeticProgressionGame Int where
@@ -194,14 +194,14 @@ instance PositionalGame ArithmeticProgressionGame Int where
 -- * Shannon Switching Game
 -------------------------------------------------------------------------------
 
-newtype ShannonSwitchingGame = ShannonSwitchingGame (Int, [((Int, Int), Maybe Player)])
+newtype ShannonSwitchingGame = ShannonSwitchingGame (Int, [((Int, Int), Position)])
 
 -- | Creates a list of all edges, input n gives n*n graph
-gridEdges :: Int -> [((Int, Int), Maybe Player)]
+gridEdges :: Int -> [((Int, Int), Position)]
 gridEdges n =
-  concat [[((j+i*n,(j+1)+i*n), Nothing), ((j+i*n,j+(i+1)*n), Nothing)] | i <- [0..n-2], j <- [0..n-2]] ++
-  [(((n-1)+i*n, (n-1)+(i+1)*n), Nothing) | i <- [0..n-2]] ++
-  [((i+(n-1)*n, (i+1)+(n-1)*n), Nothing) | i <- [0..n-2]]
+  concat [[((j+i*n,(j+1)+i*n), Empty), ((j+i*n,j+(i+1)*n), Empty)] | i <- [0..n-2], j <- [0..n-2]] ++
+  [(((n-1)+i*n, (n-1)+(i+1)*n), Empty) | i <- [0..n-2]] ++
+  [((i+(n-1)*n, (i+1)+(n-1)*n), Empty) | i <- [0..n-2]]
 
 createShannonSwitchingGame :: Int -> ShannonSwitchingGame
 createShannonSwitchingGame n = ShannonSwitchingGame (n, gridEdges n)
@@ -217,12 +217,12 @@ instance Show ShannonSwitchingGame where
     j <- [0 .. n - 2]]
     ++ [concat ["o" ++ showH (fromJust $ getPosition a (i+(n-1)*n, (i+1)+(n-1)*n)) | i <- [0 .. n - 2]] ++ "o"])
     where
-      showH (Just Player1) = "\ESC[34m───\ESC[0m"
-      showH (Just Player2) = "\ESC[31m───\ESC[0m"
-      showH Nothing        = "───"
-      showV (Just Player1) = "\ESC[34m│\ESC[0m"
-      showV (Just Player2) = "\ESC[31m│\ESC[0m"
-      showV Nothing        = "│"
+      showH (Occupied Player1) = "\ESC[34m───\ESC[0m"
+      showH (Occupied Player2) = "\ESC[31m───\ESC[0m"
+      showH Empty           = "───"
+      showV (Occupied Player1) = "\ESC[34m│\ESC[0m"
+      showV (Occupied Player2) = "\ESC[31m│\ESC[0m"
+      showV Empty           = "│"
 
 instance PositionalGame ShannonSwitchingGame (Int, Int) where
   getPosition (ShannonSwitchingGame (_, l)) c = snd <$> find ((== c) . fst) l
@@ -233,10 +233,10 @@ instance PositionalGame ShannonSwitchingGame (Int, Int) where
   gameOver (ShannonSwitchingGame (n, l))
     | path g 0 (n * n - 1) = Just (Just Player1)
     | path g (n - 1) (n * n - n) = Just (Just Player2)
-    | all (isJust . snd) l = Just Nothing
+    | all (isOccupied . snd) l = Just Nothing
     | otherwise = Nothing
     where
-      g = buildG (0, n * n - 1) (map fst $ filter ((== Just Player1) . snd) l)
+      g = buildG (0, n * n - 1) (map fst $ filter ((== Occupied Player1) . snd) l)
 
 -------------------------------------------------------------------------------
 -- * Shannon Switching Game (On a ColoredGraph)
@@ -247,11 +247,11 @@ instance PositionalGame ShannonSwitchingGame (Int, Int) where
 data ShannonSwitchingGameCG = ShannonSwitchingGameCG {
     start :: Int
   , goal  :: Int
-  , graph :: ColoredGraph Int () (Maybe Player)
+  , graph :: ColoredGraph Int () Position
   }
   deriving (Show)
 
-instance ColoredGraphTransformer Int () (Maybe Player) ShannonSwitchingGameCG where
+instance ColoredGraphTransformer Int () Position ShannonSwitchingGameCG where
   toColoredGraph = graph
   fromColoredGraph ssg graph = ssg{ graph }
 
@@ -262,8 +262,8 @@ instance PositionalGame ShannonSwitchingGameCG (Int, Int) where
   gameOver ShannonSwitchingGameCG{ start, goal, graph } =
       ifNotThen (player1WinsIf winPath) (player1LosesIf losePath) graph
     where
-      winPath = anyConnections (==2) [[start], [goal]] . filterEdges (== Just Player1)
-      losePath = not . anyConnections (==2) [[start], [goal]] . filterEdges (/= Just Player2)
+      winPath = anyConnections (==2) [[start], [goal]] . filterEdges (== Occupied Player1)
+      losePath = not . anyConnections (==2) [[start], [goal]] . filterEdges (/= Occupied Player2)
 
 createEmptyShannonSwitchingGameCG :: [(Int, Int)] -> Int -> Int -> ShannonSwitchingGameCG
 createEmptyShannonSwitchingGameCG pairs start goal = ShannonSwitchingGameCG{
@@ -275,8 +275,8 @@ createEmptyShannonSwitchingGameCG pairs start goal = ShannonSwitchingGameCG{
     addPathToMap m (from, to) = alter updateOrInsert from m
       where
         updateOrInsert existing = case existing of
-          Just (a, edges) -> Just (a, insert to Nothing edges)
-          Nothing -> Just ((), fromList [(to, Nothing)])
+          Just (a, edges) -> Just (a, insert to Empty edges)
+          Nothing -> Just ((), fromList [(to, Empty)])
 
 -- Creates a 'ShannonSwitchingGameCG' on a graph like the one from Wikipedia.
 -- https://en.wikipedia.org/wiki/Shannon_switching_game#/media/File:Shannon_game_graph.svg
@@ -303,7 +303,7 @@ wikipediaReplica = createEmptyShannonSwitchingGameCG connections 0 3
 -- * Gale
 -------------------------------------------------------------------------------
 
-newtype Gale = Gale (Map (Integer, Integer) (Maybe Player))
+newtype Gale = Gale (Map (Integer, Integer) Position)
 
 -- Creates an empty Gale playfield. Even "rows" have 4 "columns" and odd ones
 -- have 3.
@@ -312,7 +312,7 @@ emptyGale = Gale $
   fromList $
     zip
       ([0..8] >>= (\y -> [(x, y) | x <- [0..(4 - y `rem` 2)]]))
-      (repeat Nothing)
+      (repeat Empty)
 
 --    0 1 2 3 4 5 6 7 8
 --    ╔═══╦═══╦═══╦═══╗
@@ -344,13 +344,13 @@ instance Show Gale where
     where
       -- "Shows" the elements of the given row
       row y = map (\x -> showP (b ! (x, y)) y) [0..(4 - y `rem` 2)]
-      showP (Just Player1) y
+      showP (Occupied Player1) y
         | even y      = "\ESC[34m───"
         | otherwise   = " \ESC[34m│ "
-      showP (Just Player2) y
+      showP (Occupied Player2) y
         | even y      = " \ESC[31m║ "
         | otherwise   = "\ESC[31m═══"
-      showP Nothing _ = "   "
+      showP Empty _   = "   "
 
 instance PositionalGame Gale (Integer, Integer) where
   getPosition (Gale b) (x, y) = if x `rem` 2 == y `rem` 2 then lookup c b else Nothing
@@ -361,11 +361,11 @@ instance PositionalGame Gale (Integer, Integer) where
   gameOver (Gale b)
     | path player1Graph (-1) (-2) = Just $ Just Player1
     | path player2Graph (-1) (-2) = Just $ Just Player2
-    | all isJust (elems b) = Just Nothing
+    | all isOccupied (elems b) = Just Nothing
     | otherwise            = Nothing
     where
       playerGraph from to p = buildG (-2, 19) $
-        filter ((Just p ==) . snd) (assocs b) >>=
+        filter ((Occupied p ==) . snd) (assocs b) >>=
           ((\(x, y) -> [(x, y), (y, x)]) . (\((x, y), _) -> (fromInteger $ from x y, fromInteger $ to x y)))
       player1Graph = playerGraph
         (\x y -> if x == 0 then -1 else (y `div` 2) + 5 * (x + (y `rem` 2) - 1))
@@ -380,7 +380,7 @@ instance PositionalGame Gale (Integer, Integer) where
 -- * Hex
 -------------------------------------------------------------------------------
 
-data Hex = Hex Int (ColoredGraph (Int, Int) (Maybe Player) (Int, Int))
+data Hex = Hex Int (ColoredGraph (Int, Int) Position (Int, Int))
 
 emptyHex :: Int -> Hex
 emptyHex n = Hex n $ paraHexGraph n
@@ -402,13 +402,13 @@ gridShowLine :: Hex -> Int -> [String]
 gridShowLine (Hex n b) y  = [rowOffset ++ tileTop ++ [x | y/=0, x <- " /"]
                           ,rowOffset ++ "| " ++ intercalate " | " (map (\x -> showP $ fst $ fromJust $ lookup (x, n-1-y) b) [0..(n-1)]) ++ " |"
                           ] where
-  showP (Just Player1) = "1"
-  showP (Just Player2) = "2"
-  showP Nothing = " "
+  showP (Occupied Player1) = "1"
+  showP (Occupied Player2) = "2"
+  showP Empty           = " "
   rowOffset = replicate (2*(n-y-1)) ' '
   tileTop = concat $ replicate n " / \\"
 
-instance ColoredGraphTransformer (Int, Int) (Maybe Player) (Int, Int) Hex where
+instance ColoredGraphTransformer (Int, Int) Position (Int, Int) Hex where
   toColoredGraph (Hex n b) = b
   fromColoredGraph (Hex n _) = Hex n
 
@@ -421,9 +421,9 @@ instance PositionalGame Hex (Int, Int) where
       criterion =
         criteria
           -- There is a connection between 2 components, the left and right.
-          [ player1WinsIf (anyConnections (==2) [left, right]) . filterValues (==Just Player1)
+          [ player1WinsIf (anyConnections (==2) [left, right]) . filterValues (== Occupied Player1)
            -- There is a connection between 2 components, the top and bottom.
-          , player2WinsIf (anyConnections (==2) [top, bottom]) . filterValues (==Just Player2)
+          , player2WinsIf (anyConnections (==2) [top, bottom]) . filterValues (== Occupied Player2)
           ]
       left   = [(0,  i) | i <- [0..n-1]]
       right  = [(n-1,i) | i <- [0..n-1]]
@@ -434,7 +434,7 @@ instance PositionalGame Hex (Int, Int) where
 -- * Hex2
 -------------------------------------------------------------------------------
 
-data Hex2 = Hex2 Int (ColoredGraph (Int, Int) (Maybe Player) (Int, Int))
+data Hex2 = Hex2 Int (ColoredGraph (Int, Int) Position (Int, Int))
 
 emptyHex2 :: Int -> Hex2
 emptyHex2 n = Hex2 n $ paraHexGraph n
@@ -451,9 +451,9 @@ gridShowLine2 :: Hex2 -> Int -> [String]
 gridShowLine2 (Hex2 n b) y  = [rowOffset ++ tileTop ++ [x | y/=0, x <- " /"]
                           ,rowOffset ++ "| " ++ intercalate " | " (map (\x -> showP $ fst $ fromJust $ lookup (x, n-1-y) b) [0..(n-1)]) ++ " |"
                           ] where
-  showP (Just Player1) = "1"
-  showP (Just Player2) = "2"
-  showP Nothing = " "
+  showP (Occupied Player1) = "1"
+  showP (Occupied Player2) = "2"
+  showP Empty           = " "
   rowOffset = replicate (2*(n-y-1)) ' '
   tileTop = concat $ replicate n " / \\"
 
@@ -476,8 +476,8 @@ allWinningHexPaths n = winningSetPaths (paraHexGraph n) left right
 -- * Havannah
 -------------------------------------------------------------------------------
 
-newtype Havannah = Havannah (ColoredGraph (Int, Int) (Maybe Player) ())
-  deriving (ColoredGraphTransformer (Int, Int) (Maybe Player) ())
+newtype Havannah = Havannah (ColoredGraph (Int, Int) Position ())
+  deriving (ColoredGraphTransformer (Int, Int) Position ())
 
 instance Show Havannah where
   show (Havannah b) = show b
@@ -489,17 +489,17 @@ instance PositionalGame Havannah (Int, Int) where
   gameOver (Havannah b) = criterion b
     where
       criterion =
-        drawIf (all isJust . values) `unless` -- It's a draw if all tiles are owned.
+        drawIf (all isOccupied . values) `unless` -- It's a draw if all tiles are owned.
         -- Here we say that in any position where one player wins,
         -- the other player would win instead if the pieces were swapped.
-        symmetric (mapValues (nextPlayer <$>))
+        symmetric (mapValues $ mapPosition nextPlayer)
         (criteria (player1WinsIf <$> -- Player1 wins if any of these 3 criteria are satisfied.
             -- Player1 has connected 2 corners.
-          [ anyConnections (>=2) corners . filterValues (== Just Player1)
+          [ anyConnections (>=2) corners . filterValues (== Occupied Player1)
             -- player1 has connecteed 3 edges (excluding the corners).
-          , anyConnections (>=3) edges . filterValues (== Just Player1)
+          , anyConnections (>=3) edges . filterValues (== Occupied Player1)
             -- player1 has surrounded other tiles such that they can't reach the border.
-          , anyConnections (==0) border . filterValues (/= Just Player1)
+          , anyConnections (==0) border . filterValues (/= Occupied Player1)
           ]))
       corners = components $ filterG ((==3) . length . snd) b
       edges   = components $ filterG ((==4) . length . snd) b
@@ -512,8 +512,8 @@ emptyHavannah = Havannah . mapEdges (const ()) . hexHexGraph
 -- * Yavalath
 -------------------------------------------------------------------------------
 
-newtype Yavalath = Yavalath (ColoredGraph (Int, Int) (Maybe Player) String)
-  deriving (ColoredGraphTransformer (Int, Int) (Maybe Player) String)
+newtype Yavalath = Yavalath (ColoredGraph (Int, Int) Position String)
+  deriving (ColoredGraphTransformer (Int, Int) Position String)
 
 instance Show Yavalath where
   show (Yavalath b) = show b
@@ -525,15 +525,15 @@ instance PositionalGame Yavalath (Int, Int) where
   gameOver (Yavalath b) = criterion b
     where
       criterion =
-        drawIf (all isJust . values) `unless` -- It's a draw if all tiles are owned.
+        drawIf (all isOccupied . values) `unless` -- It's a draw if all tiles are owned.
         -- Here we say that in any position where one player wins,
         -- the other player would win instead if the pieces were swapped.
-        symmetric (mapValues $ fmap nextPlayer)
+        symmetric (mapValues $ mapPosition nextPlayer)
         -- Player1 looses if he has 3 in a row but wins if he has 4 or more in a row.
         -- It's important we use `unless` here because otherwise we could have conflicting
         -- outcomes from having both 3 in a row and 4 in a row at the same time.
-        (criteria (player1LosesIf . inARow (==3) <$> directions) . filterValues (== Just Player1) `unless`
-        criteria (player1WinsIf . inARow (>=4) <$> directions) . filterValues (== Just Player1))
+        (criteria (player1LosesIf . inARow (==3) <$> directions) . filterValues (== Occupied Player1) `unless`
+        criteria (player1WinsIf . inARow (>=4) <$> directions) . filterValues (== Occupied Player1))
 
       directions = ["vertical", "diagonal1", "diagonal2"]
 
@@ -553,7 +553,7 @@ emptyYavalath = Yavalath . mapEdges dirName . hexHexGraph
 -- * mnk-game
 -------------------------------------------------------------------------------
 
-data MNKGame = MNKGame Int (ColoredGraph (Int, Int) (Maybe Player) String)
+data MNKGame = MNKGame Int (ColoredGraph (Int, Int) Position String)
 
 instance Show MNKGame where
   show (MNKGame k b) = show b
@@ -563,7 +563,7 @@ instance ToJSON MNKGame where
   toJSON (MNKGame _ b) = toJSON b
 #endif
 
-instance ColoredGraphTransformer (Int, Int) (Maybe Player) String MNKGame where
+instance ColoredGraphTransformer (Int, Int) Position String MNKGame where
   toColoredGraph (MNKGame n b) = b
   fromColoredGraph (MNKGame n _) = MNKGame n
 
@@ -574,12 +574,12 @@ instance PositionalGame MNKGame (Int, Int) where
   gameOver (MNKGame k b) = criterion b
     where
       criterion =
-        drawIf (all isJust . values) `unless` -- It's a draw if all tiles are owned.
+        drawIf (all isOccupied . values) `unless` -- It's a draw if all tiles are owned.
         -- Here we say that in any position where one player wins,
         -- the other player would win instead if the pieces were swapped.
-        symmetric (mapValues $ fmap nextPlayer)
+        symmetric (mapValues $ mapPosition nextPlayer)
         -- Player1 wins if there are k or more pieces in a row in any direction.
-        (criteria (player1WinsIf . inARow (>=k) <$> directions) . filterValues (== Just Player1))
+        (criteria (player1WinsIf . inARow (>=k) <$> directions) . filterValues (== Occupied Player1))
           
 
       directions = ["vertical", "horizontal", "diagonal1", "diagonal2"]
@@ -602,7 +602,7 @@ emptyMNKGame m n k = MNKGame k $ mapEdges dirName $ rectOctGraph m n
 -- * Y
 -------------------------------------------------------------------------------
 
-newtype Y = Y (ColoredGraph (Int, Int) (Maybe Player) (Int, Int))
+newtype Y = Y (ColoredGraph (Int, Int) Position (Int, Int))
 
 instance Show Y where
   show (Y b) = show b
@@ -620,8 +620,8 @@ instance PositionalGame Y (Int, Int) where
       criterion =
         -- Here we say that in any position where one player wins,
         -- the other player would win instead if the pieces were swapped.
-        symmetric (mapValues $ fmap nextPlayer) $
-        player1WinsIf $ anyConnections (==3) [side1, side2, side3] . filterValues (== Just Player1)
+        symmetric (mapValues $ mapPosition nextPlayer) $
+        player1WinsIf $ anyConnections (==3) [side1, side2, side3] . filterValues (== Occupied Player1)
 
       dirs :: [(Int, Int)]
       dirs =
@@ -645,7 +645,7 @@ emptyY = Y . triHexGraph
 -- * Cross
 -------------------------------------------------------------------------------
 
-newtype Cross = Cross (ColoredGraph (Int, Int) (Maybe Player) (Int, Int))
+newtype Cross = Cross (ColoredGraph (Int, Int) Position (Int, Int))
 
 instance Show Cross where
   show (Cross b) = show b
@@ -661,18 +661,18 @@ instance PositionalGame Cross (Int, Int) where
   gameOver (Cross b) = criterion b
     where
       criterion =
-        drawIf (all isJust . values) `unless` -- It's a draw if all tiles are owned.
+        drawIf (all isOccupied . values) `unless` -- It's a draw if all tiles are owned.
         -- Here we say that in any position where one player wins,
         -- the other player would win instead if the pieces were swapped.
-        symmetric (mapValues (nextPlayer <$>))
+        symmetric (mapValues $ mapPosition nextPlayer)
         (criteria (player1LosesIf <$> -- you lose if you have connected 2 opposite sides.
-          [ anyConnections (==2) [side1, side4] . filterValues (== Just Player1)
-          , anyConnections (==2) [side2, side5] . filterValues (== Just Player1)
-          , anyConnections (==2) [side3, side6] . filterValues (== Just Player1)
+          [ anyConnections (==2) [side1, side4] . filterValues (== Occupied Player1)
+          , anyConnections (==2) [side2, side5] . filterValues (== Occupied Player1)
+          , anyConnections (==2) [side3, side6] . filterValues (== Occupied Player1)
           ]) `unless`
         criteria (player1WinsIf <$> -- you win if you have connected 3 non-adjacent sides.
-          [ anyConnections (==3) [side1, side3, side5] . filterValues (== Just Player1)
-          , anyConnections (==3) [side2, side4, side6] . filterValues (== Just Player1)
+          [ anyConnections (==3) [side1, side3, side5] . filterValues (== Occupied Player1)
+          , anyConnections (==3) [side2, side4, side6] . filterValues (== Occupied Player1)
           ]))
 
       dirs =
@@ -699,7 +699,7 @@ emptyCross = Cross . hexHexGraph
 -- * Connect Four
 -------------------------------------------------------------------------------
 
-data ConnectFour = ConnectFour Int (ColoredGraph (Int, Int) (Maybe Player) String)
+data ConnectFour = ConnectFour Int (ColoredGraph (Int, Int) Position String)
 
 instance Show ConnectFour where
   show (ConnectFour k b) = show b
@@ -715,12 +715,12 @@ instance PositionalGame ConnectFour (Int, Int) where
   gameOver (ConnectFour k b) = criterion b
     where
       criterion =
-        drawIf (all isJust . values) `unless` -- It's a draw if all tiles are owned.
+        drawIf (all isOccupied . values) `unless` -- It's a draw if all tiles are owned.
         -- Here we say that in any position where one player wins,
         -- the other player would win instead if the pieces were swapped.
-        symmetric (mapValues $ fmap nextPlayer)
+        symmetric (mapValues $ mapPosition nextPlayer)
         -- Player1 wins if there are k or more pieces in a row in any direction.
-        (criteria (player1WinsIf . inARow (>=k) <$> directions) . filterValues (== Just Player1))
+        (criteria (player1WinsIf . inARow (>=k) <$> directions) . filterValues (== Occupied Player1))
 
       directions = ["vertical", "horizontal", "diagonal1", "diagonal2"]
 
@@ -731,13 +731,13 @@ instance PositionalGame ConnectFour (Int, Int) where
 newMakeMove :: ConnectFour -> Player -> (Int, Int) -> Maybe ConnectFour
 newMakeMove a p coord = case getPosition a coord of
   -- If we are at bottom row, we can place the piece there.
-  Just Nothing -> if ((fst coord) == 0) 
-                    then setPosition a coord (Just p)
+  Just Empty -> if ((fst coord) == 0)
+                    then setPosition a coord (Occupied p)
                     -- Not at bottom row, check to see if position below has been filled.
                     else case getPosition a ((fst coord) -1, snd coord) of
-                      Just Nothing -> Nothing
-                      _            -> setPosition a coord (Just p)
-  _            -> Nothing
+                      Just Empty -> Nothing
+                      _          -> setPosition a coord (Occupied p)
+  _          -> Nothing
 
 emptyConnectFour :: Int -> Int -> Int -> ConnectFour
 emptyConnectFour m n k = ConnectFour k $ mapEdges dirName $ rectOctGraph m n

--- a/src/Boardgame/ColoredGraph.hs
+++ b/src/Boardgame/ColoredGraph.hs
@@ -39,6 +39,7 @@ import Data.Maybe ( fromJust, isJust, listToMaybe, mapMaybe )
 import Data.Tree (Tree(..), foldTree)
 import Control.Monad ((<=<))
 import Data.Bifunctor ( bimap, Bifunctor (first, second) )
+import Boardgame (Position(..))
 
 
 -- | A Graph with colored vertices and edges. The key of the map is 'i', the
@@ -111,8 +112,8 @@ distance (x, y) (i, j) = (abs(x - i) + abs(x + y - i - j) + abs(y - j)) `div` 2
 --   The "coordinates" of the graph will be '(Int, Int)' where '(0, 0)' is at
 --   the center. The color of edges will also be a '(Int, Int)' tuple that
 --   shows the "direction" of the edge.
-hexHexGraph :: Int -> ColoredGraph (Int, Int) (Maybe a) (Int, Int)
-hexHexGraph radius = Map.fromList ((\z -> (z , (Nothing, Map.fromList $ filter ((< radius) . distance (0, 0) . fst) $ (\i -> (hexNeighbors z !! i, hexDirections !! i)) <$> [0..5]))) <$> nodes)
+hexHexGraph :: Int -> ColoredGraph (Int, Int) Position (Int, Int)
+hexHexGraph radius = Map.fromList ((\z -> (z , (Empty, Map.fromList $ filter ((< radius) . distance (0, 0) . fst) $ (\i -> (hexNeighbors z !! i, hexDirections !! i)) <$> [0..5]))) <$> nodes)
   where
     nodes :: [Coordinate]
     nodes = (0, 0) : concatMap hexHexGraphRing [1..radius-1]
@@ -127,8 +128,8 @@ hexHexGraph radius = Map.fromList ((\z -> (z , (Nothing, Map.fromList $ filter (
 --   The "coordinates" of the graph will be '(Int, Int)' where '(0, 0)' is at
 --   the center. The color of edges will also be a '(Int, Int)' tuple that
 --   shows the "direction" of the edge.
-paraHexGraph :: Int -> ColoredGraph (Int, Int) (Maybe a) (Int, Int)
-paraHexGraph n = Map.fromList ((\z -> (z , (Nothing, Map.fromList $ filter ((\(i, j) -> i < n && i >= 0 && j < n && j >= 0) . fst) $ (\i -> (hexNeighbors z !! i, hexDirections !! i)) <$> [0..5]))) <$> nodes)
+paraHexGraph :: Int -> ColoredGraph (Int, Int) Position (Int, Int)
+paraHexGraph n = Map.fromList ((\z -> (z , (Empty, Map.fromList $ filter ((\(i, j) -> i < n && i >= 0 && j < n && j >= 0) . fst) $ (\i -> (hexNeighbors z !! i, hexDirections !! i)) <$> [0..5]))) <$> nodes)
   where
     nodes :: [Coordinate]
     nodes = [(i, j) | i <- [0..n-1], j <- [0..n-1]]
@@ -139,8 +140,8 @@ paraHexGraph n = Map.fromList ((\z -> (z , (Nothing, Map.fromList $ filter ((\(i
 --   The "coordinates" of the graph will be '(Int, Int)' where '(0, 0)' the top
 --   left vertex. The color of edges will also be a '(Int, Int)' tuple that
 --   shows the "direction" of the edge.
-rectOctGraph :: Int -> Int -> ColoredGraph (Int, Int) (Maybe a) (Int, Int)
-rectOctGraph m n = Map.fromList ((\z -> (z , (Nothing, Map.fromList $ filter ((\(i, j) -> i < m && i >= 0 && j < n && j >= 0) . fst) $ (\i -> (octoNeighbors z !! i, octoDirections !! i)) <$> [0..7]))) <$> nodes)
+rectOctGraph :: Int -> Int -> ColoredGraph (Int, Int) Position (Int, Int)
+rectOctGraph m n = Map.fromList ((\z -> (z , (Empty, Map.fromList $ filter ((\(i, j) -> i < m && i >= 0 && j < n && j >= 0) . fst) $ (\i -> (octoNeighbors z !! i, octoDirections !! i)) <$> [0..7]))) <$> nodes)
   where
     nodes :: [Coordinate]
     nodes = [(i, j) | i <- [0..m-1], j <- [0..n-1]]
@@ -151,8 +152,8 @@ rectOctGraph m n = Map.fromList ((\z -> (z , (Nothing, Map.fromList $ filter ((\
 --   The "coordinates" of the graph will be '(Int, Int)' where '(0, 0)' the top
 --   left vertex. The color of edges will also be a '(Int, Int)' tuple that
 --   shows the "direction" of the edge.
-triHexGraph :: Int -> ColoredGraph (Int, Int) (Maybe a) (Int, Int)
-triHexGraph n = Map.fromList ((\z -> (z, (Nothing, Map.fromList $ filter ((\(i, j) -> i < n && i >= 0 && j < n && j >= 0 && i + j >= n) . snd) $ (\i -> (hexNeighbors z !! i, hexDirections !! i)) <$> [0 .. 7]))) <$> nodes)
+triHexGraph :: Int -> ColoredGraph (Int, Int) Position (Int, Int)
+triHexGraph n = Map.fromList ((\z -> (z, (Empty, Map.fromList $ filter ((\(i, j) -> i < n && i >= 0 && j < n && j >= 0 && i + j >= n) . snd) $ (\i -> (hexNeighbors z !! i, hexDirections !! i)) <$> [0 .. 7]))) <$> nodes)
   where
     nodes :: [Coordinate]
     nodes = [(i, j) | i <- [0 .. n -1], j <- [0 .. n -1], i + j >= n]

--- a/src/Boardgame/Web.hs
+++ b/src/Boardgame/Web.hs
@@ -62,4 +62,4 @@ playWeb = play putState putTurn getMove putInvalidMove putGameOver
       Left _  -> jsPutInvalidInput >> getMove
       Right c -> return c
     putInvalidMove = jsPutInvalidMove
-    putGameOver = jsPutGameOver . jsonToJSVal . fmap playerToInt
+    putGameOver = jsPutGameOver . jsonToJSVal


### PR DESCRIPTION
Ulf suggested in his review of the paper that we shouldn't have `Maybe (Maybe a)` as, as we have when handling the positions and outcomes of games. This PR introduces specific data types for those occasions.

I don't know if I 100% agree with this though. `Maybe` has a lot of already written helper functions that we, or users, now must write themselves. For example, I had to write `fmap` alternatives and an `isOccupied` function to get our current code working.